### PR TITLE
removed -of year- and replaced -caseNumber- with -caseName- for In th…

### DIFF
--- a/pdf-service/data-config/order-case-transfer-qr.json
+++ b/pdf-service/data-config/order-case-transfer-qr.json
@@ -13,6 +13,12 @@
           {
             "direct": [
               {
+                "variable": "caseName",
+                "value": {
+                  "path": "$.caseName"
+                }
+              },
+              {
                 "variable": "courtName",
                 "value": {
                   "path": "$.courtName"

--- a/pdf-service/data-config/order-case-transfer.json
+++ b/pdf-service/data-config/order-case-transfer.json
@@ -13,6 +13,12 @@
           {
             "direct": [
               {
+                "variable": "caseName",
+                "value": {
+                  "path": "$.caseName"
+                }
+              },
+              {
                 "variable": "courtName",
                 "value": {
                   "path": "$.courtName"

--- a/pdf-service/data-config/order-for-mandatory-async-submissions-and-response-qr.json
+++ b/pdf-service/data-config/order-for-mandatory-async-submissions-and-response-qr.json
@@ -13,6 +13,12 @@
           {
             "direct": [
               {
+                "variable": "caseName",
+                "value": {
+                  "path": "$.caseName"
+                }
+              },
+              {
                 "variable": "courtName",
                 "value": {
                   "path": "$.courtName"

--- a/pdf-service/data-config/order-for-mandatory-async-submissions-and-response.json
+++ b/pdf-service/data-config/order-for-mandatory-async-submissions-and-response.json
@@ -13,6 +13,12 @@
           {
             "direct": [
               {
+                "variable": "caseName",
+                "value": {
+                  "path": "$.caseName"
+                }
+              },
+              {
                 "variable": "courtName",
                 "value": {
                   "path": "$.courtName"

--- a/pdf-service/data-config/order-referral-case-adr-qr.json
+++ b/pdf-service/data-config/order-referral-case-adr-qr.json
@@ -13,6 +13,12 @@
           {
             "direct": [
               {
+                "variable": "caseName",
+                "value": {
+                  "path": "$.caseName"
+                }
+              },
+              {
                 "variable": "courtName",
                 "value": {
                   "path": "$.courtName"

--- a/pdf-service/data-config/order-referral-case-adr.json
+++ b/pdf-service/data-config/order-referral-case-adr.json
@@ -13,6 +13,12 @@
           {
             "direct": [
               {
+                "variable": "caseName",
+                "value": {
+                  "path": "$.caseName"
+                }
+              },
+              {
                 "variable": "courtName",
                 "value": {
                   "path": "$.courtName"

--- a/pdf-service/format-config/application-bail-bond-qr.json
+++ b/pdf-service/format-config/application-bail-bond-qr.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "{{caseType}}/Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "{{caseType}}/Case No. {{caseNumber}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/application-bail-bond.json
+++ b/pdf-service/format-config/application-bail-bond.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "{{caseType}}/Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "{{caseType}}/Case No. {{caseNumber}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/application-case-transfer-qr.json
+++ b/pdf-service/format-config/application-case-transfer-qr.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "{{caseType}}/Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "{{caseType}}/Case No. {{caseNumber}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/application-case-transfer.json
+++ b/pdf-service/format-config/application-case-transfer.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "{{caseType}}/Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "{{caseType}}/Case No. {{caseNumber}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/application-case-withdrawal-qr.json
+++ b/pdf-service/format-config/application-case-withdrawal-qr.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "{{caseType}}/Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "{{caseType}}/Case No. {{caseNumber}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/application-case-withdrawal.json
+++ b/pdf-service/format-config/application-case-withdrawal.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "{{caseType}}/Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "{{caseType}}/Case No. {{caseNumber}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/application-delay-condonation-qr.json
+++ b/pdf-service/format-config/application-delay-condonation-qr.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "{{caseType}}/Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "{{caseType}}/Case No. {{caseNumber}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/application-delay-condonation.json
+++ b/pdf-service/format-config/application-delay-condonation.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "{{caseType}}/Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "{{caseType}}/Case No. {{caseNumber}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/application-for-checkout-request-qr.json
+++ b/pdf-service/format-config/application-for-checkout-request-qr.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "{{caseType}}/Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "{{caseType}}/Case No. {{caseNumber}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/application-for-checkout-request.json
+++ b/pdf-service/format-config/application-for-checkout-request.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "{{caseType}}/Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "{{caseType}}/Case No. {{caseNumber}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/application-generic-qr.json
+++ b/pdf-service/format-config/application-generic-qr.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "{{caseType}}/Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "{{caseType}}/Case No. {{caseNumber}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/application-generic.json
+++ b/pdf-service/format-config/application-generic.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "{{caseType}}/Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "{{caseType}}/Case No. {{caseNumber}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/application-production-of-documents-qr.json
+++ b/pdf-service/format-config/application-production-of-documents-qr.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "{{caseType}}/Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "{{caseType}}/Case No. {{caseNumber}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/application-production-of-documents.json
+++ b/pdf-service/format-config/application-production-of-documents.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "{{caseType}}/Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "{{caseType}}/Case No. {{caseNumber}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/application-reschedule-request-qr.json
+++ b/pdf-service/format-config/application-reschedule-request-qr.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "{{caseType}}/Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "{{caseType}}/Case No. {{caseNumber}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/application-reschedule-request.json
+++ b/pdf-service/format-config/application-reschedule-request.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "{{caseType}}/Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "{{caseType}}/Case No. {{caseNumber}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/application-submission-extension-qr.json
+++ b/pdf-service/format-config/application-submission-extension-qr.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "{{caseType}}/Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "{{caseType}}/Case No. {{caseNumber}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/application-submission-extension.json
+++ b/pdf-service/format-config/application-submission-extension.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "{{caseType}}/Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "{{caseType}}/Case No. {{caseNumber}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/application-submit-bail-documents-qr.json
+++ b/pdf-service/format-config/application-submit-bail-documents-qr.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "{{caseType}}/Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "{{caseType}}/Case No. {{caseNumber}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/application-submit-bail-documents.json
+++ b/pdf-service/format-config/application-submit-bail-documents.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "{{caseType}}/Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "{{caseType}}/Case No. {{caseNumber}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/case.json
+++ b/pdf-service/format-config/case.json
@@ -12,7 +12,7 @@
         "style": "header"
       },
       {
-        "text": "CASE NUMBER {{caseNumber}} of {{caseYear}}",
+        "text": "CASE NUMBER {{caseNumber}}",
         "style": "subheader"
       },
       {

--- a/pdf-service/format-config/dca-notice-qr.json
+++ b/pdf-service/format-config/dca-notice-qr.json
@@ -33,7 +33,7 @@
                     "style": "form-sub-header"
                   },
                   {
-                    "text": "Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "Case No. {{caseNumber}}",
                     "style": "form-sub-header"
                   },
                   {

--- a/pdf-service/format-config/dca-notice.json
+++ b/pdf-service/format-config/dca-notice.json
@@ -33,7 +33,7 @@
                     "style": "form-sub-header"
                   },
                   {
-                    "text": "Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "Case No. {{caseNumber}}",
                     "style": "form-sub-header"
                   },
                   {

--- a/pdf-service/format-config/mandatory-async-submissions-responses-qr.json
+++ b/pdf-service/format-config/mandatory-async-submissions-responses-qr.json
@@ -14,11 +14,11 @@
                     "style": "header"
                   },
                   {
-                    "text": "Case No. {{caseNumber}} of {{year}}",
+                    "text": "Case No. {{caseNumber}}",
                     "style": "subHeader"
                   },
                   {
-                    "text": "In the matter of: {{caseNumber}}",
+                    "text": "In the matter of: {{caseName}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/mandatory-async-submissions-responses.json
+++ b/pdf-service/format-config/mandatory-async-submissions-responses.json
@@ -14,11 +14,11 @@
                     "style": "header"
                   },
                   {
-                    "text": "Case No. {{caseNumber}} of {{year}}",
+                    "text": "Case No. {{caseNumber}}",
                     "style": "subHeader"
                   },
                   {
-                    "text": "In the matter of: {{caseNumber}}",
+                    "text": "In the matter of: {{caseName}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/order-202-crpc-qr.json
+++ b/pdf-service/format-config/order-202-crpc-qr.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "Case No: {{caseNumber}} of {{caseYear}}",
+                    "text": "Case No: {{caseNumber}}",
                     "style": "header"
                   },
                   {

--- a/pdf-service/format-config/order-202-crpc.json
+++ b/pdf-service/format-config/order-202-crpc.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "Case No. {{caseNumber}}",
                     "style": "header"
                   },
                   {

--- a/pdf-service/format-config/order-accept-voluntary-qr.json
+++ b/pdf-service/format-config/order-accept-voluntary-qr.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "Case No: {{caseNumber}} of {{caseYear}}",
+                    "text": "Case No: {{caseNumber}}",
                     "style": "header"
                   },
                   {

--- a/pdf-service/format-config/order-accept-voluntary.json
+++ b/pdf-service/format-config/order-accept-voluntary.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "Case No: {{caseNumber}} of {{caseYear}}",
+                    "text": "Case No: {{caseNumber}}",
                     "style": "header"
                   },
                   {

--- a/pdf-service/format-config/order-acceptance-rejection-case-qr.json
+++ b/pdf-service/format-config/order-acceptance-rejection-case-qr.json
@@ -18,7 +18,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "In Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "In Case No. {{caseNumber}}",
                     "style": "header"
                   },
                   {

--- a/pdf-service/format-config/order-acceptance-rejection-case.json
+++ b/pdf-service/format-config/order-acceptance-rejection-case.json
@@ -18,7 +18,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "In Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "In Case No. {{caseNumber}}",
                     "style": "header"
                   },
                   {

--- a/pdf-service/format-config/order-acceptance-rejection-dca-qr.json
+++ b/pdf-service/format-config/order-acceptance-rejection-dca-qr.json
@@ -18,7 +18,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "In Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "In Case No. {{caseNumber}}",
                     "style": "header"
                   },
                   {

--- a/pdf-service/format-config/order-acceptance-rejection-dca.json
+++ b/pdf-service/format-config/order-acceptance-rejection-dca.json
@@ -18,7 +18,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "In Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "In Case No. {{caseNumber}}",
                     "style": "header"
                   },
                   {

--- a/pdf-service/format-config/order-bail-acceptance-qr.json
+++ b/pdf-service/format-config/order-bail-acceptance-qr.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "Case No. {{caseNumber}}",
                     "style": "header"
                   },
                   {

--- a/pdf-service/format-config/order-bail-acceptance.json
+++ b/pdf-service/format-config/order-bail-acceptance.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "Case No. {{caseNumber}}",
                     "style": "header"
                   },
                   {

--- a/pdf-service/format-config/order-bail-rejection-qr.json
+++ b/pdf-service/format-config/order-bail-rejection-qr.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "Case No. {{caseNumber}}",
                     "style": "header"
                   },
                   {

--- a/pdf-service/format-config/order-bail-rejection.json
+++ b/pdf-service/format-config/order-bail-rejection.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "Case No. {{caseNumber}}",
                     "style": "header"
                   },
                   {

--- a/pdf-service/format-config/order-case-transfer-qr.json
+++ b/pdf-service/format-config/order-case-transfer-qr.json
@@ -14,11 +14,11 @@
                     "style": "header"
                   },
                   {
-                    "text": "Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "Case No. {{caseNumber}}",
                     "style": "header"
                   },
                   {
-                    "text": "In the matter of: {{caseNumber}}",
+                    "text": "In the matter of: {{caseName}}",
                     "style": "header"
                   },
                   {

--- a/pdf-service/format-config/order-case-transfer.json
+++ b/pdf-service/format-config/order-case-transfer.json
@@ -14,11 +14,11 @@
                     "style": "header"
                   },
                   {
-                    "text": "Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "Case No. {{caseNumber}}",
                     "style": "header"
                   },
                   {
-                    "text": "In the matter of: {{caseNumber}}",
+                    "text": "In the matter of: {{caseName}}",
                     "style": "header"
                   },
                   {

--- a/pdf-service/format-config/order-case-withdrawal-acceptance-qr.json
+++ b/pdf-service/format-config/order-case-withdrawal-acceptance-qr.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "Case No. {{caseNumber}}",
                     "style": "header"
                   },
                   {

--- a/pdf-service/format-config/order-case-withdrawal-acceptance.json
+++ b/pdf-service/format-config/order-case-withdrawal-acceptance.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "Case No. {{caseNumber}}",
                     "style": "header"
                   },
                   {

--- a/pdf-service/format-config/order-case-withdrawal-rejected-qr.json
+++ b/pdf-service/format-config/order-case-withdrawal-rejected-qr.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "Case No. {{caseNumber}}",
                     "style": "header"
                   },
                   {

--- a/pdf-service/format-config/order-case-withdrawal-rejected.json
+++ b/pdf-service/format-config/order-case-withdrawal-rejected.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "Case No. {{caseNumber}}",
                     "style": "header"
                   },
                   {

--- a/pdf-service/format-config/order-for-extension-deadline-qr.json
+++ b/pdf-service/format-config/order-for-extension-deadline-qr.json
@@ -14,11 +14,11 @@
                     "style": "header"
                   },
                   {
-                    "text": "Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "Case No. {{caseNumber}}",
                     "style": "header"
                   },
                   {
-                    "text": "In the matter of: {{caseNumber}}",
+                    "text": "In the matter of: {{caseName}}",
                     "style": "header"
                   },
                   {

--- a/pdf-service/format-config/order-for-extension-deadline.json
+++ b/pdf-service/format-config/order-for-extension-deadline.json
@@ -14,11 +14,11 @@
                     "style": "header"
                   },
                   {
-                    "text": "Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "Case No. {{caseNumber}}",
                     "style": "header"
                   },
                   {
-                    "text": "In the matter of: {{caseNumber}}",
+                    "text": "In the matter of: {{caseName}}",
                     "style": "header"
                   },
                   {

--- a/pdf-service/format-config/order-for-mandatory-async-submissions-and-response-qr.json
+++ b/pdf-service/format-config/order-for-mandatory-async-submissions-and-response-qr.json
@@ -14,11 +14,11 @@
                     "style": "header"
                   },
                   {
-                    "text": "Case No. {{caseNumber}} of {{year}}",
+                    "text": "Case No. {{caseNumber}}",
                     "style": "header"
                   },
                   {
-                    "text": "In the matter of: {{caseNumber}}",
+                    "text": "In the matter of: {{caseName}}",
                     "style": "header"
                   },
                   {

--- a/pdf-service/format-config/order-for-mandatory-async-submissions-and-response.json
+++ b/pdf-service/format-config/order-for-mandatory-async-submissions-and-response.json
@@ -14,11 +14,11 @@
                     "style": "header"
                   },
                   {
-                    "text": "Case No. {{caseNumber}} of {{year}}",
+                    "text": "Case No. {{caseNumber}}",
                     "style": "header"
                   },
                   {
-                    "text": "In the matter of: {{caseNumber}}",
+                    "text": "In the matter of: {{caseName}}",
                     "style": "header"
                   },
                   {

--- a/pdf-service/format-config/order-initiate-reschedule-qr.json
+++ b/pdf-service/format-config/order-initiate-reschedule-qr.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "Case No. {{caseNumber}} of {{year}}",
+                    "text": "Case No. {{caseNumber}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/order-initiate-reschedule.json
+++ b/pdf-service/format-config/order-initiate-reschedule.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "Case No. {{caseNumber}} of {{year}}",
+                    "text": "Case No. {{caseNumber}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/order-notice-bnss-dca-qr.json
+++ b/pdf-service/format-config/order-notice-bnss-dca-qr.json
@@ -18,7 +18,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "In Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "In Case No. {{caseNumber}}",
                     "style": "header"
                   },
                   {

--- a/pdf-service/format-config/order-notice-bnss-dca.json
+++ b/pdf-service/format-config/order-notice-bnss-dca.json
@@ -18,7 +18,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "In Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "In Case No. {{caseNumber}}",
                     "style": "header"
                   },
                   {

--- a/pdf-service/format-config/order-notice-qr.json
+++ b/pdf-service/format-config/order-notice-qr.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "Case No. {{caseNumber}}",
                     "style": "header"
                   },
                   {

--- a/pdf-service/format-config/order-notice.json
+++ b/pdf-service/format-config/order-notice.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "Case No. {{caseNumber}}",
                     "style": "header"
                   },
                   {

--- a/pdf-service/format-config/order-referral-case-adr-qr.json
+++ b/pdf-service/format-config/order-referral-case-adr-qr.json
@@ -14,11 +14,11 @@
                       "style": "header"
                     },
                     {
-                      "text": "Case No. {{caseNumber}} of {{caseYear}}",
+                      "text": "Case No. {{caseNumber}}",
                       "style": "header"
                     },
                     {
-                      "text": "In the matter of: {{caseNumber}}",
+                      "text": "In the matter of: {{caseName}}",
                       "style": "header"
                     },
                     {

--- a/pdf-service/format-config/order-referral-case-adr.json
+++ b/pdf-service/format-config/order-referral-case-adr.json
@@ -14,11 +14,11 @@
                       "style": "header"
                     },
                     {
-                      "text": "Case No. {{caseNumber}} of {{caseYear}}",
+                      "text": "Case No. {{caseNumber}}",
                       "style": "header"
                     },
                     {
-                      "text": "In the matter of: {{caseNumber}}",
+                      "text": "In the matter of: {{caseName}}",
                       "style": "header"
                     },
                     {

--- a/pdf-service/format-config/order-reject-application-submission-deadline-qr.json
+++ b/pdf-service/format-config/order-reject-application-submission-deadline-qr.json
@@ -14,11 +14,11 @@
                     "style": "header"
                   },
                   {
-                    "text": "Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "Case No. {{caseNumber}}",
                     "style": "header"
                   },
                   {
-                    "text": "In the matter of: {{caseNumber}}",
+                    "text": "In the matter of: {{caseName}}",
                     "style": "header"
                   },
                   {

--- a/pdf-service/format-config/order-reject-application-submission-deadline.json
+++ b/pdf-service/format-config/order-reject-application-submission-deadline.json
@@ -14,11 +14,11 @@
                     "style": "header"
                   },
                   {
-                    "text": "Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "Case No. {{caseNumber}}",
                     "style": "header"
                   },
                   {
-                    "text": "In the matter of: {{caseNumber}}",
+                    "text": "In the matter of: {{caseName}}",
                     "style": "header"
                   },
                   {

--- a/pdf-service/format-config/order-reject-voluntary-qr.json
+++ b/pdf-service/format-config/order-reject-voluntary-qr.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "Case No: {{caseNumber}} of {{caseYear}}",
+                    "text": "Case No: {{caseNumber}}",
                     "style": "header"
                   },
                   {

--- a/pdf-service/format-config/order-reject-voluntary.json
+++ b/pdf-service/format-config/order-reject-voluntary.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "Case No: {{caseNumber}} of {{caseYear}}",
+                    "text": "Case No: {{caseNumber}}",
                     "style": "header"
                   },
                   {

--- a/pdf-service/format-config/order-set-terms-of-bail-qr.json
+++ b/pdf-service/format-config/order-set-terms-of-bail-qr.json
@@ -18,7 +18,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "In Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "In Case No. {{caseNumber}}",
                     "style": "header"
                   },
                   {

--- a/pdf-service/format-config/order-set-terms-of-bail.json
+++ b/pdf-service/format-config/order-set-terms-of-bail.json
@@ -18,7 +18,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "In Case No. {{caseNumber}} of {{caseYear}}",
+                    "text": "In Case No. {{caseNumber}}",
                     "style": "header"
                   },
                   {

--- a/pdf-service/format-config/schedule-hearing-date-qr.json
+++ b/pdf-service/format-config/schedule-hearing-date-qr.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "Case No. {{caseNumber}} of {{year}}",
+                    "text": "Case No. {{caseNumber}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/schedule-hearing-date.json
+++ b/pdf-service/format-config/schedule-hearing-date.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "Case No. {{caseNumber}} of {{year}}",
+                    "text": "Case No. {{caseNumber}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/summons-accused-qr.json
+++ b/pdf-service/format-config/summons-accused-qr.json
@@ -25,7 +25,7 @@
                     "style": "form-sub-header"
                   },
                   {
-                    "text": "Summary Trial No. {{courtCaseNumber}} of {{caseYear}}",
+                    "text": "Summary Trial No. {{courtCaseNumber}}",
                     "style": "form-sub-header"
                   },
                   {

--- a/pdf-service/format-config/summons-accused.json
+++ b/pdf-service/format-config/summons-accused.json
@@ -25,7 +25,7 @@
                     "style": "form-sub-header"
                   },
                   {
-                    "text": "Summary Trial No. {{courtCaseNumber}} of {{caseYear}}",
+                    "text": "Summary Trial No. {{courtCaseNumber}}",
                     "style": "form-sub-header"
                   },
                   {

--- a/pdf-service/format-config/summons-issue-qr.json
+++ b/pdf-service/format-config/summons-issue-qr.json
@@ -14,11 +14,11 @@
                     "style": "header"
                   },
                   {
-                    "text": "Case No. {{caseNumber}} of {{year}}",
+                    "text": "Case No. {{caseNumber}}",
                     "style": "subHeader"
                   },
                   {
-                    "text": "In the matter of: {{caseNumber}}",
+                    "text": "In the matter of: {{caseName}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/summons-issue.json
+++ b/pdf-service/format-config/summons-issue.json
@@ -14,11 +14,11 @@
                     "style": "header"
                   },
                   {
-                    "text": "Case No. {{caseNumber}} of {{year}}",
+                    "text": "Case No. {{caseNumber}}",
                     "style": "subHeader"
                   },
                   {
-                    "text": "In the matter of: {{caseNumber}}",
+                    "text": "In the matter of: {{caseName}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/summons-witness-qr.json
+++ b/pdf-service/format-config/summons-witness-qr.json
@@ -35,7 +35,7 @@
                     "style": "form-sub-header"
                   },
                   {
-                    "text": "Summary Trial No. {{courtCaseNumber}} of {{caseYear}}",
+                    "text": "Summary Trial No. {{courtCaseNumber}}",
                     "style": "form-sub-header"
                   }
                 ],

--- a/pdf-service/format-config/summons-witness.json
+++ b/pdf-service/format-config/summons-witness.json
@@ -35,7 +35,7 @@
                     "style": "form-sub-header"
                   },
                   {
-                    "text": "Summary Trial No. {{courtCaseNumber}} of {{caseYear}}",
+                    "text": "Summary Trial No. {{courtCaseNumber}}",
                     "style": "form-sub-header"
                   }
                 ],

--- a/pdf-service/format-config/warrants-bailable.json
+++ b/pdf-service/format-config/warrants-bailable.json
@@ -33,7 +33,7 @@
                     "style": "form-sub-header"
                   },
                   {
-                    "text": "Summary Trial No. {{courtCaseNumber}} of {{caseYear}}",
+                    "text": "Summary Trial No. {{courtCaseNumber}}",
                     "style": "form-sub-header"
                   }
                 ],

--- a/pdf-service/format-config/warrants-non-bailable.json
+++ b/pdf-service/format-config/warrants-non-bailable.json
@@ -33,7 +33,7 @@
                     "style": "form-sub-header"
                   },
                   {
-                    "text": "Summary Trial No. {{courtCaseNumber}} of {{caseYear}}",
+                    "text": "Summary Trial No. {{courtCaseNumber}}",
                     "style": "form-sub-header"
                   }
                 ],

--- a/pdf-service/format-config/witness-deposition.json
+++ b/pdf-service/format-config/witness-deposition.json
@@ -64,7 +64,7 @@
               { "text": "Miscellaneous", "style": "label" }
             ],
             [
-              { "text": "{{caseNumber}} of {{caseYear}}", "style": "label", "alignment": "right" }
+              { "text": "{{caseNumber}}", "style": "label", "alignment": "right" }
             ],
             [
               { "text": "Committal Proceeding Sessions", "style": "label", "colSpan": 1 }
@@ -231,7 +231,7 @@
               { "text": "Miscellaneous Case No ", "style": "label" }
             ],
             [
-              { "text": "{{caseNumber}} of {{caseYear}}", "style": "label", "alignment": "right" }
+              { "text": "{{caseNumber}}", "style": "label", "alignment": "right" }
             ],
             [
               { "text": "Committal Proceedings", "style": "label" }


### PR DESCRIPTION
…e matter of

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Data Configuration Updates**
  - Added `caseName` mapping to multiple PDF service configuration files
  - Expanded data configuration to include additional case-related variables

- **Document Format Changes**
  - Removed case year references from numerous document templates
  - Simplified case number and header text across multiple document types
  - Replaced case number with case name in some document sections

- **Formatting Modifications**
  - Standardized case information display across various PDF templates
  - Reduced redundant year information in document headers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->