### PR TITLE
Bug 2922 templatechanges

### DIFF
--- a/pdf-service/format-config/bnss-notice-qr.json
+++ b/pdf-service/format-config/bnss-notice-qr.json
@@ -29,11 +29,11 @@
                     "alignment": "center"
                   },
                   {
-                    "text": "IN THE COURT OF {{courtName}} MAGISTRATE OF {{judgeName}}",
+                    "text": "IN THE {{courtName}}",
                     "style": "form-sub-header"
                   },
                   {
-                    "text": "CMP No. {{cmpNumber}}",
+                    "text": "{{cmpNumber}}",
                     "style": "form-sub-header"
                   },
                   {

--- a/pdf-service/format-config/bnss-notice-qr.json
+++ b/pdf-service/format-config/bnss-notice-qr.json
@@ -29,7 +29,7 @@
                     "alignment": "center"
                   },
                   {
-                    "text": "IN THE {{courtName}}",
+                    "text": "In The {{courtName}}",
                     "style": "form-sub-header"
                   },
                   {

--- a/pdf-service/format-config/bnss-notice.json
+++ b/pdf-service/format-config/bnss-notice.json
@@ -29,11 +29,11 @@
                     "alignment": "center"
                   },
                   {
-                    "text": "IN THE COURT OF {{courtName}} MAGISTRATE OF {{judgeName}}",
+                    "text": "IN THE {{courtName}}",
                     "style": "form-sub-header"
                   },
                   {
-                    "text": "CMP No. {{cmpNumber}}",
+                    "text": "{{cmpNumber}}",
                     "style": "form-sub-header"
                   },
                   {

--- a/pdf-service/format-config/bnss-notice.json
+++ b/pdf-service/format-config/bnss-notice.json
@@ -29,7 +29,7 @@
                     "alignment": "center"
                   },
                   {
-                    "text": "IN THE {{courtName}}",
+                    "text": "In The {{courtName}}",
                     "style": "form-sub-header"
                   },
                   {

--- a/pdf-service/format-config/dca-notice-qr.json
+++ b/pdf-service/format-config/dca-notice-qr.json
@@ -29,7 +29,7 @@
                     "alignment": "center"
                   },
                   {
-                    "text": "IN THE COURT OF {{courtName}} MAGISTRATE OF {{judgeName}}",
+                    "text": "In The {{courtName}}",
                     "style": "form-sub-header"
                   },
                   {

--- a/pdf-service/format-config/dca-notice.json
+++ b/pdf-service/format-config/dca-notice.json
@@ -29,7 +29,7 @@
                     "alignment": "center"
                   },
                   {
-                    "text": "IN THE COURT OF {{courtName}} MAGISTRATE OF {{judgeName}}",
+                    "text": "In The {{courtName}}",
                     "style": "form-sub-header"
                   },
                   {

--- a/pdf-service/format-config/summons-accused.json
+++ b/pdf-service/format-config/summons-accused.json
@@ -21,7 +21,7 @@
                     "style": "form-header"
                   },
                   {
-                    "text": "IN THE {{courtName}}",
+                    "text": "In The {{courtName}}",
                     "style": "form-sub-header"
                   },
                   {

--- a/pdf-service/format-config/summons-accused.json
+++ b/pdf-service/format-config/summons-accused.json
@@ -21,7 +21,7 @@
                     "style": "form-header"
                   },
                   {
-                    "text": "IN THE COURT OF {{courtName}} MAGISTRATE OF {{judgeName}}",
+                    "text": "IN THE {{courtName}}",
                     "style": "form-sub-header"
                   },
                   {


### PR DESCRIPTION
[#2922](https://github.com/pucardotorg/dristi/issues/2922)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated header text in multiple PDF service configuration files
  - Simplified court header format across various notice and summons documents
  - Removed "Magistrate of" reference and standardized text capitalization
  - Simplified case number display by removing "CMP No." prefix

<!-- end of auto-generated comment: release notes by coderabbit.ai -->