### PR TITLE
[bug-fix] enhancement #2922

### DIFF
--- a/pdf-service/format-config/application-bail-bond-qr.json
+++ b/pdf-service/format-config/application-bail-bond-qr.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "CMP/ST No. {{caseNumber}}",
+                    "text": "{{caseNumber}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/application-bail-bond.json
+++ b/pdf-service/format-config/application-bail-bond.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "CMP/ST No. {{caseNumber}}",
+                    "text": "{{caseNumber}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/application-case-settlement-qr.json
+++ b/pdf-service/format-config/application-case-settlement-qr.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "{{caseName}} and {{caseNumber}}",
+                    "text": "{{caseNumber}} and {{caseName}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/application-case-settlement.json
+++ b/pdf-service/format-config/application-case-settlement.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "{{caseName}} and {{caseNumber}}",
+                    "text": "{{caseNumber}} and {{caseName}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/application-case-transfer-qr.json
+++ b/pdf-service/format-config/application-case-transfer-qr.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "CMP/ST No. {{caseNumber}}",
+                    "text": "{{caseNumber}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/application-case-transfer.json
+++ b/pdf-service/format-config/application-case-transfer.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "CMP/ST No. {{caseNumber}}",
+                    "text": "{{caseNumber}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/application-case-withdrawal-qr.json
+++ b/pdf-service/format-config/application-case-withdrawal-qr.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "CMP/ST No. {{caseNumber}}",
+                    "text": "{{caseNumber}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/application-case-withdrawal.json
+++ b/pdf-service/format-config/application-case-withdrawal.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "CMP/ST No. {{caseNumber}}",
+                    "text": "{{caseNumber}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/application-delay-condonation-qr.json
+++ b/pdf-service/format-config/application-delay-condonation-qr.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "CMP/ST No. {{caseNumber}}",
+                    "text": "{{caseNumber}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/application-delay-condonation.json
+++ b/pdf-service/format-config/application-delay-condonation.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "CMP/ST No. {{caseNumber}}",
+                    "text": "{{caseNumber}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/application-for-checkout-request-qr.json
+++ b/pdf-service/format-config/application-for-checkout-request-qr.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "CMP/ST No. {{caseNumber}}",
+                    "text": "{{caseNumber}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/application-for-checkout-request.json
+++ b/pdf-service/format-config/application-for-checkout-request.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "CMP/ST No. {{caseNumber}}",
+                    "text": "{{caseNumber}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/application-generic-qr.json
+++ b/pdf-service/format-config/application-generic-qr.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "CMP/ST No. {{caseNumber}}",
+                    "text": "{{caseNumber}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/application-generic.json
+++ b/pdf-service/format-config/application-generic.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "CMP/ST No. {{caseNumber}}",
+                    "text": "{{caseNumber}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/application-production-of-documents-qr.json
+++ b/pdf-service/format-config/application-production-of-documents-qr.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "CMP/ST No. {{caseNumber}}",
+                    "text": "{{caseNumber}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/application-production-of-documents.json
+++ b/pdf-service/format-config/application-production-of-documents.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "CMP/ST No. {{caseNumber}}",
+                    "text": "{{caseNumber}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/application-reschedule-request-qr.json
+++ b/pdf-service/format-config/application-reschedule-request-qr.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "CMP/ST No. {{caseNumber}}",
+                    "text": "{{caseNumber}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/application-reschedule-request.json
+++ b/pdf-service/format-config/application-reschedule-request.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "CMP/ST No. {{caseNumber}}",
+                    "text": "{{caseNumber}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/application-submission-extension-qr.json
+++ b/pdf-service/format-config/application-submission-extension-qr.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "CMP/ST No. {{caseNumber}}",
+                    "text": "{{caseNumber}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/application-submission-extension.json
+++ b/pdf-service/format-config/application-submission-extension.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "CMP/ST No. {{caseNumber}}",
+                    "text": "{{caseNumber}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/application-submit-bail-documents-qr.json
+++ b/pdf-service/format-config/application-submit-bail-documents-qr.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "CMP/ST No. {{caseNumber}}",
+                    "text": "{{caseNumber}}",
                     "style": "subHeader"
                   },
                   {

--- a/pdf-service/format-config/application-submit-bail-documents.json
+++ b/pdf-service/format-config/application-submit-bail-documents.json
@@ -14,7 +14,7 @@
                     "style": "header"
                   },
                   {
-                    "text": "CMP/ST No. {{caseNumber}}",
+                    "text": "{{caseNumber}}",
                     "style": "subHeader"
                   },
                   {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Simplified document displays by removing the redundant "CMP/ST No." prefix from case number fields across various PDF templates.
	- Adjusted the ordering of case details on settlement documents so that the case number appears before the case name, ensuring a more streamlined and user-friendly presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->