### PR TITLE
[bug-fix] #2942

### DIFF
--- a/pdf-service/format-config/application-case-transfer-qr.json
+++ b/pdf-service/format-config/application-case-transfer-qr.json
@@ -26,7 +26,7 @@
                     "style": "applicationTitle"
                   },
                   {
-                    "text": "NO. {{caseNo}} FROM {{originalCourt}} TO {{newCourt}}",
+                    "text": "{{caseNo}} FROM {{originalCourt}} TO {{newCourt}}",
                     "style": "applicationTitle"
                   },
                   {

--- a/pdf-service/format-config/application-case-transfer.json
+++ b/pdf-service/format-config/application-case-transfer.json
@@ -26,7 +26,7 @@
                     "style": "applicationTitle"
                   },
                   {
-                    "text": "NO. {{caseNo}} FROM {{originalCourt}} TO {{newCourt}}",
+                    "text": "{{caseNo}} FROM {{originalCourt}} TO {{newCourt}}",
                     "style": "applicationTitle"
                   },
                   {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the document templates for case transfers by removing the "NO." prefix from the case number, resulting in a cleaner and more streamlined display for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->