### PR TITLE
add indexer for open hearing

### DIFF
--- a/egov-indexer/open-hearing-indexer.yml
+++ b/egov-indexer/open-hearing-indexer.yml
@@ -1,0 +1,33 @@
+ServiceMaps:
+  serviceName: Hearing Service
+  version: 1.0.0
+  mappings: 
+    - topic: open-hearing-topic
+      configKey: INDEX
+      indexes: 
+        - name: open-hearing-index
+          type: general
+          id: $.hearingUuid
+          isBulk: false
+          jsonPath: $
+          customJsonMapping: 
+            indexMapping: {"Data":{"hearingDetails":{}}}
+            fieldMapping: 
+              - inJsonPath: $.hearingUuid
+                outJsonPath: $.Data.hearingDetails.hearingUuid
+              - inJsonPath: $.tenantId
+                outJsonPath: $.Data.hearingDetails.tenantId
+              - inJsonPath: $.filingNumber
+                outJsonPath: $.Data.hearingDetails.filingNumber
+              - inJsonPath: $.caseTitle
+                outJsonPath: $.Data.hearingDetails.caseTitle
+              - inJsonPath: $.caseUuid
+                outJsonPath: $.Data.hearingDetails.caseUuid
+              - inJsonPath: $.hearingNumber
+                outJsonPath: $.Data.hearingDetails.hearingNumber
+              - inJsonPath: $.caseNumber
+                outJsonPath: $.Data.hearingDetails.caseNumber
+              - inJsonPath: $.stage
+                outJsonPath: $.Data.hearingDetails.stage
+              - inJsonPath: $.status
+                outJsonPath: $.Data.hearingDetails.status


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new configuration that enhances the Hearing Service by establishing robust data mapping and indexing settings for open hearing records. This update streamlines data extraction and organization, ensuring a more consistent and accurate display of hearing details for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->