### PR TITLE
[bug-fix] #3288 Added space between complainant name and age

### DIFF
--- a/pdf-service/format-config/complainant-case-efiling.json
+++ b/pdf-service/format-config/complainant-case-efiling.json
@@ -42,7 +42,7 @@
                                       "bold": true
                                     },
                                     {
-                                      "text": "aged {{complainantAge}}"
+                                      "text": " aged {{complainantAge}}"
                                     }
                                   ],
                                   "style": "bodyText"


### PR DESCRIPTION
https://github.com/pucardotorg/dristi/issues/3288#issuecomment-2713088903

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Adjusted PDF text formatting to ensure a proper space appears before the complainant's age, enhancing the visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->