### PR TITLE
[bug-fix] removed "CMP No" title from Admit Order title

### DIFF
--- a/pdf-service/format-config/order-admit-case-qr.json
+++ b/pdf-service/format-config/order-admit-case-qr.json
@@ -14,10 +14,6 @@
                     "style": "header"
                   },
                   {
-                    "text": "CMP No {{cmpNumber}}",
-                    "style": "header"
-                  },
-                  {
                     "text": "In Case No. {{caseNumber}}",
                     "style": "header"
                   },

--- a/pdf-service/format-config/order-admit-case.json
+++ b/pdf-service/format-config/order-admit-case.json
@@ -14,10 +14,6 @@
                     "style": "header"
                   },
                   {
-                    "text": "CMP No {{cmpNumber}}",
-                    "style": "header"
-                  },
-                  {
                     "text": "In Case No. {{caseNumber}}",
                     "style": "header"
                   },


### PR DESCRIPTION
https://github.com/pucardotorg/dristi/issues/3354#issuecomment-2713478337

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the CMP number header from PDF documents so that generated files no longer display the CMP number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->