### PR TITLE
Legal Benefit fund amount is not showing in Case filing payment receipt generated

### DIFF
--- a/pdf-service/data-config/etreasury-receipt.json
+++ b/pdf-service/data-config/etreasury-receipt.json
@@ -130,6 +130,13 @@
                 "default":""
               },
               {
+                "variable":"legalBenefitFee",
+                "value":{
+                  "path":"$.legalBenefitFee"
+                },
+                "default":""
+              },
+              {
                 "variable":"totalAmount",
                 "value":{
                   "path":"$.totalAmount"

--- a/pdf-service/format-config/etreasury-receipt.json
+++ b/pdf-service/format-config/etreasury-receipt.json
@@ -331,6 +331,20 @@
             ],
             [
               {
+                "text": "Legal Benefit Fund:",
+                "bold": true,
+                "border": [true, true, true, true],
+                "margin": [0, 5, 0, 5]
+              },
+              {
+                "text": "Rs. {{legalBenefitFee}}",
+                "border": [true, true, true, true],
+                "margin": [0, 5, 0, 5],
+                "alignment": "left"
+              }
+            ],
+            [
+              {
                 "text": "Total",
                 "bold": true,
                 "border": [true, true, true, true],


### PR DESCRIPTION
https://github.com/pucardotorg/dristi/issues/4022

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added display of "Legal Benefit Fund" and its corresponding amount in the Payment Details section of the eTreasury receipt PDF.
  
- **Chores**
  - Updated configuration to include mapping for "legalBenefitFee" data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->