### PR TITLE
bugfix in pdf template

### DIFF
--- a/pdf-service/format-config/attachment-generic.json
+++ b/pdf-service/format-config/attachment-generic.json
@@ -82,12 +82,6 @@
                 "text": "Signature",
                 "style": "footer-signature"
               }
-            ],
-            [
-              {
-                "text": "Seal of the Court",
-                "style": "footer-seal"
-              }
             ]
           ]
         },
@@ -124,16 +118,11 @@
       },
       "form-sub-body": {
         "fontSize": 12,
-        "color": "#484848"
-      },
-      "form-sub-body-right": {
-        "fontSize": 12,
         "color": "#484848",
         "margin": [0, 10, 0, 10],
         "alignment": "justify"
       },
       "footer-content": {
-        "color": "#484848",
         "fontSize": 11,
         "color": "#484848"
       },

--- a/pdf-service/format-config/order-issue-attachment-qr.json
+++ b/pdf-service/format-config/order-issue-attachment-qr.json
@@ -3,9 +3,6 @@
   "config": {
     "content": [
       {
-        "text": "Order for S85"
-      },
-      {
         "table": {
           "widths": [
             "*"

--- a/pdf-service/format-config/order-issue-attachment.json
+++ b/pdf-service/format-config/order-issue-attachment.json
@@ -3,9 +3,6 @@
   "config": {
     "content": [
       {
-        "text": "Order for S85"
-      },
-      {
         "table": {
           "widths": [
             "*"
@@ -73,15 +70,15 @@
                     "style": "bodyText"
                   },
                   {
-                    "text": "The attachment shall be executed with due respect to the rights of the individuals involved and any property that may be affected.",
+                    "text": "The proclamation shall be executed with due respect to the rights of the individuals involved and any property that may be affected.",
                     "style": "bodyText"
                   },
                   {
-                    "text": "All necessary precautions and measures shall be taken to ensure that the execution of the attachment does not result in unnecessary harm or damage.",
+                    "text": "All necessary precautions and measures shall be taken to ensure that the execution of the proclamation does not result in unnecessary harm or damage.",
                     "style": "bodyText"
                   },
                   {
-                    "text": "The Court retains jurisdiction to cancel/review the execution of the attachment and to issue further orders as necessary.",
+                    "text": "The Court retains jurisdiction to cancel/review the execution of the proclamation and to issue further orders as necessary.",
                     "style": "bodyText"
                   },
                   {

--- a/pdf-service/format-config/order-issue-proclamation-qr.json
+++ b/pdf-service/format-config/order-issue-proclamation-qr.json
@@ -3,9 +3,6 @@
   "config": {
     "content": [
       {
-        "text": "Order for S84"
-      },
-      {
         "table": {
           "widths": [
             "*"
@@ -57,7 +54,7 @@
                     "style": "bodyText"
                   },
                   {
-                    "text": "WHEREAS, the Court has determined that sufficient grounds exist for the issuance of Proclamation for Person Absconding.",
+                    "text": "WHEREAS, the Court has determined that sufficient grounds exist for the issuance of a proclamation for a person absconding.",
                     "style": "bodyText"
                   },
                   {
@@ -65,7 +62,7 @@
                     "style": "bodyText"
                   },
                   {
-                    "text": "A Proclamation for Person Absconding against the party {{personName}} is hereby ISSUED.",
+                    "text": "A Proclamation for a person absconding against the party {{personName}} is hereby ISSUED.",
                     "style": "bodyText"
                   },
                   {

--- a/pdf-service/format-config/order-issue-proclamation.json
+++ b/pdf-service/format-config/order-issue-proclamation.json
@@ -3,9 +3,6 @@
   "config": {
     "content": [
       {
-        "text": "Order for S84"
-      },
-      {
         "table": {
           "widths": [
             "*"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Content Updates
  - Removed redundant “Order for S84/S85” headings from order PDFs.
  - Updated wording to reference a “proclamation” instead of an “attachment” where applicable.
  - Standardized capitalization and phrasing in proclamation text.

- Style/Layout
  - Streamlined footer to a two-column layout: “(Seal of the Court)” and “Signature”; removed the extra footer row.
  - Cleaned up styling to ensure consistent colors and typography across forms.

- Bug Fixes
  - Resolved duplicate styling that could cause minor rendering inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->