### PR TITLE
minor bug fix in  84-85 order

### DIFF
--- a/pdf-service/format-config/attachment-generic.json
+++ b/pdf-service/format-config/attachment-generic.json
@@ -45,6 +45,12 @@
           "body": [
             [
               {
+                "text": "To The District Magistrate/Collector of the District of {{district}}",
+                "style": "form-sub-body"
+              }
+            ],
+            [
+              {
                 "text": "WHEREAS complaint has been made before me that {{partyType}} {{respondentName}} of {{respondentAddress}} has committed (or is suspected to have committed) an offence punishable under section 138 of Negotiable Instruments Act 1881, and it has been returned to a warrant of arrest thereupon issued that the said {{respondentName}} cannot be found; and whereas it has been shown to my satisfaction that the said {{respondentName}} has absconded (or is concealing himself to avoid the service of the said warrant) and thereupon a Proclamation has been or is being duly issued and published requiring the said {{respondentName}} to appear to answer the said charge within {{chargeDays}} days; and whereas the said {{respondentName}} is possessed of certain land paying revenue to Government in the village (or town) of {{village}}, in the District of {{district}}",
                 "style": "form-sub-body"
               }

--- a/pdf-service/format-config/order-issue-attachment-qr.json
+++ b/pdf-service/format-config/order-issue-attachment-qr.json
@@ -66,7 +66,7 @@
                     "style": "bodyText"
                   },
                   {
-                    "text": "The law enforcement authorities are directed to execute the attachment in accordance with the law and report back to the Court.",
+                    "text": "The law enforcement authorities are directed to execute the proclamation in accordance with the law and report back to the Court.",
                     "style": "bodyText"
                   },
                   {

--- a/pdf-service/format-config/order-issue-attachment.json
+++ b/pdf-service/format-config/order-issue-attachment.json
@@ -66,7 +66,7 @@
                     "style": "bodyText"
                   },
                   {
-                    "text": "The law enforcement authorities are directed to execute the attachment in accordance with the law and report back to the Court.",
+                    "text": "The law enforcement authorities are directed to execute the proclamation in accordance with the law and report back to the Court.",
                     "style": "bodyText"
                   },
                   {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a header line addressing the District Magistrate/Collector in the attachment document, appearing before the “WHEREAS …” paragraph.

- Bug Fixes
  - Corrected wording in relevant order documents: replaced “execute the attachment” with “execute the proclamation” to align with intended phrasing across standard and QR variants.

- Chores
  - Updated PDF template content to reflect the above changes without altering logic, layout structure, or placeholders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->