### PR TITLE
change the static file location

### DIFF
--- a/pdf-service/data-config/aDiary.json
+++ b/pdf-service/data-config/aDiary.json
@@ -43,12 +43,12 @@
               },
               {
                 "variable": "nationalEmblem",
-                "url": "http://minio-filestore.backbone-prod:8080/minio-filestore/v1/files/id?tenantId=kl&fileStoreId=626816f6-0050-447a-ae8d-e1ed351263be",
+                "url": "https://oncourts.kerala.gov.in/minio-filestore/v1/files/id?tenantId=kl&fileStoreId=626816f6-0050-447a-ae8d-e1ed351263be",
                 "type": "image"
               },
               {
                 "variable": "onCourtsLogo",
-                "url": "http://minio-filestore.backbone-prod:8080/minio-filestore/v1/files/id?tenantId=kl&fileStoreId=cfab6a6e-8e7c-40cd-970b-733da79807e5",
+                "url": "https://oncourts.kerala.gov.in/minio-filestore/v1/files/id?tenantId=kl&fileStoreId=cfab6a6e-8e7c-40cd-970b-733da79807e5",
                 "type": "image"
               }
             ]

--- a/pdf-service/data-config/bDiary.json
+++ b/pdf-service/data-config/bDiary.json
@@ -50,12 +50,12 @@
               },
               {
                 "variable": "nationalEmblem",
-                "url": "http://minio-filestore.backbone-prod:8080/minio-filestore/v1/files/id?tenantId=kl&fileStoreId=299094a2-7da4-4b1b-a1b4-3a26ea03ac88",
+                "url": "https://oncourts.kerala.gov.in/minio-filestore/v1/files/id?tenantId=kl&fileStoreId=299094a2-7da4-4b1b-a1b4-3a26ea03ac88",
                 "type": "image"
               },
               {
                 "variable": "onCourtsLogo",
-                "url": "http://minio-filestore.backbone-prod:8080/minio-filestore/v1/files/id?tenantId=kl&fileStoreId=cfab6a6e-8e7c-40cd-970b-733da79807e5",
+                "url": "https://oncourts.kerala.gov.in/minio-filestore/v1/files/id?tenantId=kl&fileStoreId=cfab6a6e-8e7c-40cd-970b-733da79807e5",
                 "type": "image"
               }
             ]

--- a/pdf-service/data-config/causeListPdf.json
+++ b/pdf-service/data-config/causeListPdf.json
@@ -49,12 +49,12 @@
               },
               {
                 "variable": "nationalEmblem",
-                "url": "http://minio-filestore.backbone-prod:8080/minio-filestore/v1/files/id?tenantId=kl&fileStoreId=299094a2-7da4-4b1b-a1b4-3a26ea03ac88",
+                "url": "https://oncourts.kerala.gov.in/minio-filestore/v1/files/id?tenantId=kl&fileStoreId=299094a2-7da4-4b1b-a1b4-3a26ea03ac88",
                 "type": "image"
               },
               {
                 "variable": "onCourtsLogo",
-                "url": "http://minio-filestore.backbone-prod:8080/minio-filestore/v1/files/id?tenantId=kl&fileStoreId=cfab6a6e-8e7c-40cd-970b-733da79807e5",
+                "url": "https://oncourts.kerala.gov.in/minio-filestore/v1/files/id?tenantId=kl&fileStoreId=cfab6a6e-8e7c-40cd-970b-733da79807e5",
                 "type": "image"
               }
             ]

--- a/pdf-service/data-config/causelist.json
+++ b/pdf-service/data-config/causelist.json
@@ -14,7 +14,7 @@
             "direct": [
               {
                 "variable": "logoImage",
-                "url": "http://minio-filestore.backbone-prod:8080/minio-filestore/v1/files/id?tenantId=kl&fileStoreId=299094a2-7da4-4b1b-a1b4-3a26ea03ac88",
+                "url": "https://oncourts.kerala.gov.in/minio-filestore/v1/files/id?tenantId=kl&fileStoreId=299094a2-7da4-4b1b-a1b4-3a26ea03ac88",
                 "type": "image"
               },
               {
@@ -32,4 +32,3 @@
     ]
   }
 }
-

--- a/pdf-service/data-config/etreasury-receipt.json
+++ b/pdf-service/data-config/etreasury-receipt.json
@@ -14,7 +14,7 @@
             "direct": [
               {
                 "variable": "logoImage",
-                "url": "http://minio-filestore.backbone-prod:8080/minio-filestore/v1/files/id?tenantId=kl&fileStoreId=299094a2-7da4-4b1b-a1b4-3a26ea03ac88",
+                "url": "https://oncourts.kerala.gov.in/minio-filestore/v1/files/id?tenantId=kl&fileStoreId=299094a2-7da4-4b1b-a1b4-3a26ea03ac88",
                 "type": "image"
               },
               {
@@ -81,67 +81,67 @@
                 "default": ""
               },
               {
-                "variable":"caseType",
-                "value":{
-                  "path":"$.caseType"
+                "variable": "caseType",
+                "value": {
+                  "path": "$.caseType"
                 },
-                "default":"NIA S138"
+                "default": "NIA S138"
               },
               {
-                "variable":"caseName",
-                "value":{
-                  "path":"$.caseName"
+                "variable": "caseName",
+                "value": {
+                  "path": "$.caseName"
                 },
-                "default":""
+                "default": ""
               },
               {
-                "variable":"caseNumber",
-                "value":{
-                  "path":"$.caseNumber"
+                "variable": "caseNumber",
+                "value": {
+                  "path": "$.caseNumber"
                 },
-                "default":""
+                "default": ""
               },
               {
-                "variable":"purposeOfPayment",
-                "value":{
-                  "path":"$.purposeOfPayment"
+                "variable": "purposeOfPayment",
+                "value": {
+                  "path": "$.purposeOfPayment"
                 },
-                "default":""
+                "default": ""
               },
               {
-                "variable":"courtFee",
-                "value":{
-                  "path":"$.courtFee"
+                "variable": "courtFee",
+                "value": {
+                  "path": "$.courtFee"
                 },
-                "default":""
+                "default": ""
               },
               {
-                "variable":"advocateWelfareFund",
-                "value":{
-                  "path":"$.advocateWelfareFund"
+                "variable": "advocateWelfareFund",
+                "value": {
+                  "path": "$.advocateWelfareFund"
                 },
-                "default":""
+                "default": ""
               },
               {
-                "variable":"advocateClerkWelfareFund",
-                "value":{
-                  "path":"$.advocateClerkWelfareFund"
+                "variable": "advocateClerkWelfareFund",
+                "value": {
+                  "path": "$.advocateClerkWelfareFund"
                 },
-                "default":""
+                "default": ""
               },
               {
-                "variable":"legalBenefitFee",
-                "value":{
-                  "path":"$.legalBenefitFee"
+                "variable": "legalBenefitFee",
+                "value": {
+                  "path": "$.legalBenefitFee"
                 },
-                "default":""
+                "default": ""
               },
               {
-                "variable":"totalAmount",
-                "value":{
-                  "path":"$.totalAmount"
+                "variable": "totalAmount",
+                "value": {
+                  "path": "$.totalAmount"
                 },
-                "default":""
+                "default": ""
               }
             ]
           }
@@ -150,4 +150,3 @@
     ]
   }
 }
-

--- a/pdf-service/data-config/summons-accused.json
+++ b/pdf-service/data-config/summons-accused.json
@@ -147,12 +147,12 @@
               },
               {
                 "variable": "qrCodeFirst",
-                "url": "http://minio-filestore.backbone-prod:8080/minio-filestore/v1/files/id?tenantId=kl&fileStoreId=0ad94ee3-371f-46d7-b063-ede2495a1912",
+                "url": "https://oncourts.kerala.gov.in/minio-filestore/v1/files/id?tenantId=kl&fileStoreId=0ad94ee3-371f-46d7-b063-ede2495a1912",
                 "type": "image"
               },
               {
                 "variable": "qrCodeSecond",
-                "url": "http://minio-filestore.backbone-prod:8080/minio-filestore/v1/files/id?tenantId=kl&fileStoreId=084f00e9-fee8-432d-927d-183d78123f33",
+                "url": "https://oncourts.kerala.gov.in/minio-filestore/v1/files/id?tenantId=kl&fileStoreId=084f00e9-fee8-432d-927d-183d78123f33",
                 "type": "image"
               },
               {
@@ -169,4 +169,3 @@
     ]
   }
 }
-


### PR DESCRIPTION
https://github.com/pucardotorg/dristi/issues/4639
Summary:- 
The error occured due to empty filestore id for pay slip as there was error while generating pdf for payment slip which was caused due to misconfiguration for file url in kerala configs for some pdf templates.
Error Logs:-
etreasury-service:-
2025-09-11 08:55:36.732+0000 ERROR --- [080-exec-6] o.e.e.util.PdfServiceUtil -- : Error getting response from Pdf Service
2025-09-11 08:55:36.734+0000 ERROR --- [080-exec-6] o.e.e.service.PaymentService -- : Error occurred when creating pdf for payment

pdf-service:-
info: received createnosave request on key: etreasury-receipt {"timestamp":" 2025-09-11 08:55:36.489+0000"}
at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:56:26) {"timestamp":" 2025-09-11 08:55:36.727+0000"}
error: error while loading image from: http://minio-filestore.backbone-prod:8080/minio-filestore/v1/files/id?tenantId=kl&fileStoreId=299094a2-7da4-4b1b-a1b4-3a26ea03ac88 {"timestamp":" 2025-09-11 08:55:36.728+0000"}