### PR TITLE
Update pdf config for treasury receipt to pick fee amounts dynamically

### DIFF
--- a/pdf-service/data-config/etreasury-receipt.json
+++ b/pdf-service/data-config/etreasury-receipt.json
@@ -109,32 +109,9 @@
                 "default":""
               },
               {
-                "variable":"courtFee",
-                "value":{
-                  "path":"$.courtFee"
-                },
-                "default":""
-              },
-              {
-                "variable":"advocateWelfareFund",
-                "value":{
-                  "path":"$.advocateWelfareFund"
-                },
-                "default":""
-              },
-              {
-                "variable":"advocateClerkWelfareFund",
-                "value":{
-                  "path":"$.advocateClerkWelfareFund"
-                },
-                "default":""
-              },
-              {
-                "variable":"legalBenefitFee",
-                "value":{
-                  "path":"$.legalBenefitFee"
-                },
-                "default":""
+                "variable": "feeBreakDown",
+                "value": { "path": "$.feeBreakDown" },
+                "default": []
               },
               {
                 "variable":"totalAmount",

--- a/pdf-service/format-config/etreasury-receipt.json
+++ b/pdf-service/format-config/etreasury-receipt.json
@@ -287,62 +287,22 @@
         "table": {
           "widths": ["*", "*"],
           "body": [
+            "{{#feeBreakDown}}",
             [
               {
-                "text": "Court Fees:",
+                "text": "{{feeName}}",
                 "bold": true,
                 "border": [true, true, true, true],
                 "margin": [0, 5, 0, 5]
               },
               {
-                "text": "Rs. {{courtFee}}",
+                "text": "Rs. {{feeAmount}}",
                 "border": [true, true, true, true],
                 "margin": [0, 5, 0, 5],
                 "alignment": "left"
               }
             ],
-            [
-              {
-                "text": "Fee for advocate welfare fund:",
-                "bold": true,
-                "border": [true, true, true, true],
-                "margin": [0, 5, 0, 5]
-              },
-              {
-                "text": "Rs. {{advocateWelfareFund}}",
-                "border": [true, true, true, true],
-                "margin": [0, 5, 0, 5],
-                "alignment": "left"
-              }
-            ],
-            [
-              {
-                "text": "Fee for clerk welfare fund:",
-                "bold": true,
-                "border": [true, true, true, true],
-                "margin": [0, 5, 0, 5]
-              },
-              {
-                "text": "Rs. {{advocateClerkWelfareFund}}",
-                "border": [true, true, true, true],
-                "margin": [0, 5, 0, 5],
-                "alignment": "left"
-              }
-            ],
-            [
-              {
-                "text": "Legal Benefit Fund:",
-                "bold": true,
-                "border": [true, true, true, true],
-                "margin": [0, 5, 0, 5]
-              },
-              {
-                "text": "Rs. {{legalBenefitFee}}",
-                "border": [true, true, true, true],
-                "margin": [0, 5, 0, 5],
-                "alignment": "left"
-              }
-            ],
+            "{{/feeBreakDown}}",
             [
               {
                 "text": "Total",


### PR DESCRIPTION
https://github.com/pucardotorg/dristi/issues/5635

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured fee display mechanism to support dynamic fee breakdowns instead of fixed individual fee fields. The system now renders fees based on a flexible breakdown configuration, allowing for more adaptable fee presentation in receipts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->