### PR TITLE
fix: remove duplicate 'Judicial Magistrate of First Class' from deposition footer

### DIFF
--- a/pdf-service/format-config/new-witness-deposition.json
+++ b/pdf-service/format-config/new-witness-deposition.json
@@ -107,10 +107,6 @@
                   {
                     "text": "Date: {{date}}",
                     "style": "judgeSignature"
-                  },
-                  {
-                    "text": "Judicial Magistrate of First Class",
-                    "style": "judgeSignature"
                   }
                 ],
                 "alignment": "left",


### PR DESCRIPTION
## Summary
- Fixes duplicate "Judicial Magistrate of First Class" text appearing twice in the footer of the deposition template
- The title was hardcoded after the `Date` field in `new-witness-deposition.json`, in addition to being rendered dynamically via `{{judgePlaceholder}}`
- Removed the hardcoded entry, leaving only the dynamic placeholder

## Test plan
- [ ] Generate a witness deposition PDF and verify "Judicial Magistrate of First Class" appears only once in the footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)