### PR TITLE
fix: remove duplicate 'Judicial Magistrate of First Class' from deposition footer #5688

### DIFF
--- a/pdf-service/format-config/new-witness-deposition.json
+++ b/pdf-service/format-config/new-witness-deposition.json
@@ -107,10 +107,6 @@
                   {
                     "text": "Date: {{date}}",
                     "style": "judgeSignature"
-                  },
-                  {
-                    "text": "Judicial Magistrate of First Class",
-                    "style": "judgeSignature"
                   }
                 ],
                 "alignment": "left",


### PR DESCRIPTION
## Summary

Cherry-pick of [#755](https://github.com/pucardotorg/kerala-configs/pull/755) from `develop` → `master`.

Fixes https://github.com/pucardotorg/dristi/issues/5688

The title "Judicial Magistrate of First Class" was hardcoded after the `Date` field in `new-witness-deposition.json`, in addition to being rendered dynamically via `{{judgePlaceholder}}`. Removed the hardcoded entry, leaving only the dynamic placeholder so the designation text appears only once in the footer.

## Test plan

- [ ] Generate a witness deposition PDF and verify "Judicial Magistrate of First Class" appears only once in the footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated witness deposition template to dynamically display the current date in the judge-signature section instead of fixed text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->