### PR TITLE
feat(pdf): add Next Hearing Date line to warrant/summons/notice templates

### DIFF
--- a/pdf-service/format-config/bnss-notice-epost.json
+++ b/pdf-service/format-config/bnss-notice-epost.json
@@ -50,11 +50,6 @@
         "layout": "noBorders"
       },
       {
-        "text": "Next Hearing Date: {{hearingDate}}",
-        "style": "next-hearing-date",
-        "layout": "noBorders"
-      },
-      {
         "columns": [
           {
             "text": "Between:",
@@ -79,6 +74,11 @@
           }
         ],
         "margin": [0, 10]
+      },
+      {
+        "text": "Next Hearing Date: {{hearingDate}}",
+        "style": "next-hearing-date",
+        "layout": "noBorders"
       },
       {
         "table": {

--- a/pdf-service/format-config/bnss-notice-epost.json
+++ b/pdf-service/format-config/bnss-notice-epost.json
@@ -50,6 +50,11 @@
         "layout": "noBorders"
       },
       {
+        "text": "Next Hearing Date: {{hearingDate}}",
+        "style": "next-hearing-date",
+        "layout": "noBorders"
+      },
+      {
         "columns": [
           {
             "text": "Between:",
@@ -410,6 +415,13 @@
       }
     ],
     "styles": {
+      "next-hearing-date": {
+        "fontSize": 12,
+        "bold": true,
+        "color": "#000000",
+        "alignment": "right",
+        "margin": [0, 0, 0, 10]
+      },
       "form-header": {
         "color": "#252525",
         "fontFamily": "Roboto",

--- a/pdf-service/format-config/bnss-notice.json
+++ b/pdf-service/format-config/bnss-notice.json
@@ -50,11 +50,6 @@
         "layout": "noBorders"
       },
       {
-        "text": "Next Hearing Date: {{hearingDate}}",
-        "style": "next-hearing-date",
-        "layout": "noBorders"
-      },
-      {
         "columns": [
           {
             "text": "Between:",
@@ -79,6 +74,11 @@
           }
         ],
         "margin": [0, 10]
+      },
+      {
+        "text": "Next Hearing Date: {{hearingDate}}",
+        "style": "next-hearing-date",
+        "layout": "noBorders"
       },
       {
         "table": {

--- a/pdf-service/format-config/bnss-notice.json
+++ b/pdf-service/format-config/bnss-notice.json
@@ -50,6 +50,11 @@
         "layout": "noBorders"
       },
       {
+        "text": "Next Hearing Date: {{hearingDate}}",
+        "style": "next-hearing-date",
+        "layout": "noBorders"
+      },
+      {
         "columns": [
           {
             "text": "Between:",
@@ -384,6 +389,13 @@
       }
     ],
     "styles": {
+      "next-hearing-date": {
+        "fontSize": 12,
+        "bold": true,
+        "color": "#000000",
+        "alignment": "right",
+        "margin": [0, 0, 0, 10]
+      },
       "form-header": {
         "color": "#252525",
         "fontFamily": "Roboto",

--- a/pdf-service/format-config/dca-notice-epost.json
+++ b/pdf-service/format-config/dca-notice-epost.json
@@ -50,6 +50,11 @@
         "layout": "noBorders"
       },
       {
+        "text": "Next Hearing Date: {{hearingDate}}",
+        "style": "next-hearing-date",
+        "layout": "noBorders"
+      },
+      {
         "columns": [
           {
             "text": "Between:",
@@ -411,6 +416,13 @@
       }
     ],
     "styles": {
+      "next-hearing-date": {
+        "fontSize": 12,
+        "bold": true,
+        "color": "#000000",
+        "alignment": "right",
+        "margin": [0, 0, 0, 10]
+      },
       "form-header": {
         "color": "#252525",
         "fontFamily": "Roboto",

--- a/pdf-service/format-config/dca-notice-epost.json
+++ b/pdf-service/format-config/dca-notice-epost.json
@@ -50,11 +50,6 @@
         "layout": "noBorders"
       },
       {
-        "text": "Next Hearing Date: {{hearingDate}}",
-        "style": "next-hearing-date",
-        "layout": "noBorders"
-      },
-      {
         "columns": [
           {
             "text": "Between:",
@@ -79,6 +74,11 @@
           }
         ],
         "margin": [0, 10]
+      },
+      {
+        "text": "Next Hearing Date: {{hearingDate}}",
+        "style": "next-hearing-date",
+        "layout": "noBorders"
       },
       {
         "table": {

--- a/pdf-service/format-config/dca-notice.json
+++ b/pdf-service/format-config/dca-notice.json
@@ -50,11 +50,6 @@
         "layout": "noBorders"
       },
       {
-        "text": "Next Hearing Date: {{hearingDate}}",
-        "style": "next-hearing-date",
-        "layout": "noBorders"
-      },
-      {
         "columns": [
           {
             "text": "Between:",
@@ -79,6 +74,11 @@
           }
         ],
         "margin": [0, 10]
+      },
+      {
+        "text": "Next Hearing Date: {{hearingDate}}",
+        "style": "next-hearing-date",
+        "layout": "noBorders"
       },
       {
         "table": {

--- a/pdf-service/format-config/dca-notice.json
+++ b/pdf-service/format-config/dca-notice.json
@@ -50,6 +50,11 @@
         "layout": "noBorders"
       },
       {
+        "text": "Next Hearing Date: {{hearingDate}}",
+        "style": "next-hearing-date",
+        "layout": "noBorders"
+      },
+      {
         "columns": [
           {
             "text": "Between:",
@@ -385,6 +390,13 @@
       }
     ],
     "styles": {
+      "next-hearing-date": {
+        "fontSize": 12,
+        "bold": true,
+        "color": "#000000",
+        "alignment": "right",
+        "margin": [0, 0, 0, 10]
+      },
       "form-header": {
         "color": "#252525",
         "fontFamily": "Roboto",

--- a/pdf-service/format-config/summons-accused.json
+++ b/pdf-service/format-config/summons-accused.json
@@ -58,6 +58,11 @@
         "layout": "noBorders"
       },
       {
+        "text": "Next Hearing Date: {{hearingDate}}",
+        "style": "next-hearing-date",
+        "layout": "noBorders"
+      },
+      {
         "style": "form-body",
         "table": {
           "widths": ["*"],
@@ -437,6 +442,13 @@
       }
     ],
     "styles": {
+      "next-hearing-date": {
+        "fontSize": 12,
+        "bold": true,
+        "color": "#000000",
+        "alignment": "right",
+        "margin": [0, 0, 0, 10]
+      },
       "form-header": {
         "color": "#484848",
         "fontFamily": "Roboto",

--- a/pdf-service/format-config/summons-witness.json
+++ b/pdf-service/format-config/summons-witness.json
@@ -54,6 +54,11 @@
         "layout": "noBorders"
       },
       {
+        "text": "Next Hearing Date: {{hearingDate}}",
+        "style": "next-hearing-date",
+        "layout": "noBorders"
+      },
+      {
         "style": "form-body",
         "table": {
           "widths": ["*"],
@@ -111,6 +116,13 @@
       }
     ],
     "styles": {
+      "next-hearing-date": {
+        "fontSize": 12,
+        "bold": true,
+        "color": "#000000",
+        "alignment": "right",
+        "margin": [0, 0, 0, 10]
+      },
       "form-header": {
         "color": "#484848",
         "fontFamily": "Roboto",

--- a/pdf-service/format-config/warrant-generic.json
+++ b/pdf-service/format-config/warrant-generic.json
@@ -31,6 +31,11 @@
         "layout": "noBorders"
       },
       {
+        "text": "Next Hearing Date: {{hearingDate}}",
+        "style": "next-hearing-date",
+        "layout": "noBorders"
+      },
+      {
         "style": "form-body",
         "table": {
           "widths": ["*"],
@@ -122,6 +127,13 @@
         "fontSize": 12,
         "color": "#484848",
         "alignment": "right"
+      },
+      "next-hearing-date": {
+        "fontSize": 12,
+        "bold": true,
+        "color": "#000000",
+        "alignment": "right",
+        "margin": [0, 0, 0, 10]
       },
       "footer-content": {
         "color": "#484848",

--- a/pdf-service/format-config/warrant-generic.json
+++ b/pdf-service/format-config/warrant-generic.json
@@ -31,7 +31,15 @@
         "layout": "noBorders"
       },
       {
-        "text": "Next Hearing Date: {{hearingDate}}",
+        "text": [
+          {
+            "text": "Next Hearing Date: "
+          },
+          {
+            "text": "{{hearingDate}}",
+            "bold": false
+          }
+        ],
         "style": "next-hearing-date",
         "layout": "noBorders"
       },

--- a/pdf-service/format-config/warrant-generic.json
+++ b/pdf-service/format-config/warrant-generic.json
@@ -31,15 +31,7 @@
         "layout": "noBorders"
       },
       {
-        "text": [
-          {
-            "text": "Next Hearing Date: "
-          },
-          {
-            "text": "{{hearingDate}}",
-            "bold": false
-          }
-        ],
+        "text": "Next Hearing Date: {{hearingDate}}",
         "style": "next-hearing-date",
         "layout": "noBorders"
       },

--- a/pdf-service/format-config/warrants-bailable.json
+++ b/pdf-service/format-config/warrants-bailable.json
@@ -54,6 +54,11 @@
         "layout": "noBorders"
       },
       {
+        "text": "Next Hearing Date: {{hearingDate}}",
+        "style": "next-hearing-date",
+        "layout": "noBorders"
+      },
+      {
         "style": "form-body",
         "table": {
           "widths": [
@@ -215,6 +220,13 @@
       }
     ],
     "styles": {
+      "next-hearing-date": {
+        "fontSize": 12,
+        "bold": true,
+        "color": "#000000",
+        "alignment": "right",
+        "margin": [0, 0, 0, 10]
+      },
       "tl-head": {
         "fillColor": "white",
         "margin": [

--- a/pdf-service/format-config/warrants-non-bailable.json
+++ b/pdf-service/format-config/warrants-non-bailable.json
@@ -55,15 +55,7 @@
         "layout": "noBorders"
       },
       {
-        "text": [
-          {
-            "text": "Next Hearing Date: "
-          },
-          {
-            "text": "{{hearingDate}}",
-            "bold": false
-          }
-        ],
+        "text": "Next Hearing Date: {{hearingDate}}",
         "style": "next-hearing-date",
         "layout": "noBorders"
       },

--- a/pdf-service/format-config/warrants-non-bailable.json
+++ b/pdf-service/format-config/warrants-non-bailable.json
@@ -55,7 +55,15 @@
         "layout": "noBorders"
       },
       {
-        "text": "Next Hearing Date: {{hearingDate}}",
+        "text": [
+          {
+            "text": "Next Hearing Date: "
+          },
+          {
+            "text": "{{hearingDate}}",
+            "bold": false
+          }
+        ],
         "style": "next-hearing-date",
         "layout": "noBorders"
       },

--- a/pdf-service/format-config/warrants-non-bailable.json
+++ b/pdf-service/format-config/warrants-non-bailable.json
@@ -55,6 +55,11 @@
         "layout": "noBorders"
       },
       {
+        "text": "Next Hearing Date: {{hearingDate}}",
+        "style": "next-hearing-date",
+        "layout": "noBorders"
+      },
+      {
         "style": "form-body",
         "table": {
           "widths": [
@@ -176,6 +181,18 @@
         "fontSize": 12,
         "color": "#484848",
         "alignment": "right"
+      },
+      "next-hearing-date": {
+        "fontSize": 12,
+        "bold": true,
+        "color": "#000000",
+        "alignment": "right",
+        "margin": [
+          0,
+          0,
+          0,
+          10
+        ]
       },
       "footer-content": {
         "color": "#484848",

--- a/pdf-service/format-config/witness-warrant-pdf.json
+++ b/pdf-service/format-config/witness-warrant-pdf.json
@@ -54,6 +54,11 @@
         "layout": "noBorders"
       },
       {
+        "text": "Next Hearing Date: {{hearingDate}}",
+        "style": "next-hearing-date",
+        "layout": "noBorders"
+      },
+      {
         "style": "form-body",
         "table": {
           "widths": [
@@ -129,6 +134,13 @@
       }
     ],
     "styles": {
+      "next-hearing-date": {
+        "fontSize": 12,
+        "bold": true,
+        "color": "#000000",
+        "alignment": "right",
+        "margin": [0, 0, 0, 10]
+      },
       "tl-head": {
         "fillColor": "white",
         "margin": [


### PR DESCRIPTION
## What
Adds a bold, right-aligned **Next Hearing Date: {{hearingDate}}** line directly below the title block in the following `pdf-service` format-config templates:

- `warrant-generic`
- `warrants-non-bailable`
- `warrants-bailable`
- `witness-warrant-pdf`
- `summons-accused`
- `summons-witness`
- `bnss-notice`, `bnss-notice-epost`
- `dca-notice`, `dca-notice-epost`

Each template also gets a shared `next-hearing-date` style (bold, right-aligned).

## Why
The hearing date was not shown on warrant/summons/notice PDFs. `hearingDate` already flows end-to-end (set by `summons-svc` `PdfServiceUtil.createSummonsPdfFromTask` and mapped in every data-config); only the format-config render line was missing.

## Scope / notes
- **format-config only** — no data-config or backend changes (data already wired).
- `-qr` / `-qr-epost` variants intentionally **not** included.
- Date format left as-is ("Nth day of Month YYYY"); the dd/MM/yyyy request needs a `summons-svc` change and is deferred.

## Pre-existing wiring caveats to confirm (not fixed here)
- Witness warrant: backend key is `warrant-witness` but only `witness-warrant-pdf` config exists/loads.
- E-post notices: backend appends `-e-post` but config files are named `-epost`.

Related to https://github.com/pucardotorg/dristi/issues/5796

🤖 Generated with [Claude Code](https://claude.com/claude-code)