### PR TITLE
feat(pdf): add Next Hearing Date line to warrant/summons/notice templates (cherry-pick)

### DIFF
--- a/pdf-service/format-config/bnss-notice-epost.json
+++ b/pdf-service/format-config/bnss-notice-epost.json
@@ -76,6 +76,11 @@
         "margin": [0, 10]
       },
       {
+        "text": "Next Hearing Date: {{hearingDate}}",
+        "style": "next-hearing-date",
+        "layout": "noBorders"
+      },
+      {
         "table": {
           "widths": ["*"],
           "body": [
@@ -410,6 +415,13 @@
       }
     ],
     "styles": {
+      "next-hearing-date": {
+        "fontSize": 12,
+        "bold": true,
+        "color": "#000000",
+        "alignment": "right",
+        "margin": [0, 0, 0, 10]
+      },
       "form-header": {
         "color": "#252525",
         "fontFamily": "Roboto",

--- a/pdf-service/format-config/bnss-notice.json
+++ b/pdf-service/format-config/bnss-notice.json
@@ -76,6 +76,11 @@
         "margin": [0, 10]
       },
       {
+        "text": "Next Hearing Date: {{hearingDate}}",
+        "style": "next-hearing-date",
+        "layout": "noBorders"
+      },
+      {
         "table": {
           "widths": ["*"],
           "body": [
@@ -384,6 +389,13 @@
       }
     ],
     "styles": {
+      "next-hearing-date": {
+        "fontSize": 12,
+        "bold": true,
+        "color": "#000000",
+        "alignment": "right",
+        "margin": [0, 0, 0, 10]
+      },
       "form-header": {
         "color": "#252525",
         "fontFamily": "Roboto",

--- a/pdf-service/format-config/dca-notice-epost.json
+++ b/pdf-service/format-config/dca-notice-epost.json
@@ -76,6 +76,11 @@
         "margin": [0, 10]
       },
       {
+        "text": "Next Hearing Date: {{hearingDate}}",
+        "style": "next-hearing-date",
+        "layout": "noBorders"
+      },
+      {
         "table": {
           "widths": ["*"],
           "body": [
@@ -411,6 +416,13 @@
       }
     ],
     "styles": {
+      "next-hearing-date": {
+        "fontSize": 12,
+        "bold": true,
+        "color": "#000000",
+        "alignment": "right",
+        "margin": [0, 0, 0, 10]
+      },
       "form-header": {
         "color": "#252525",
         "fontFamily": "Roboto",

--- a/pdf-service/format-config/dca-notice.json
+++ b/pdf-service/format-config/dca-notice.json
@@ -76,6 +76,11 @@
         "margin": [0, 10]
       },
       {
+        "text": "Next Hearing Date: {{hearingDate}}",
+        "style": "next-hearing-date",
+        "layout": "noBorders"
+      },
+      {
         "table": {
           "widths": ["*"],
           "body": [
@@ -385,6 +390,13 @@
       }
     ],
     "styles": {
+      "next-hearing-date": {
+        "fontSize": 12,
+        "bold": true,
+        "color": "#000000",
+        "alignment": "right",
+        "margin": [0, 0, 0, 10]
+      },
       "form-header": {
         "color": "#252525",
         "fontFamily": "Roboto",

--- a/pdf-service/format-config/summons-accused.json
+++ b/pdf-service/format-config/summons-accused.json
@@ -58,6 +58,11 @@
         "layout": "noBorders"
       },
       {
+        "text": "Next Hearing Date: {{hearingDate}}",
+        "style": "next-hearing-date",
+        "layout": "noBorders"
+      },
+      {
         "style": "form-body",
         "table": {
           "widths": ["*"],
@@ -437,6 +442,13 @@
       }
     ],
     "styles": {
+      "next-hearing-date": {
+        "fontSize": 12,
+        "bold": true,
+        "color": "#000000",
+        "alignment": "right",
+        "margin": [0, 0, 0, 10]
+      },
       "form-header": {
         "color": "#484848",
         "fontFamily": "Roboto",

--- a/pdf-service/format-config/summons-witness.json
+++ b/pdf-service/format-config/summons-witness.json
@@ -54,6 +54,11 @@
         "layout": "noBorders"
       },
       {
+        "text": "Next Hearing Date: {{hearingDate}}",
+        "style": "next-hearing-date",
+        "layout": "noBorders"
+      },
+      {
         "style": "form-body",
         "table": {
           "widths": ["*"],
@@ -111,6 +116,13 @@
       }
     ],
     "styles": {
+      "next-hearing-date": {
+        "fontSize": 12,
+        "bold": true,
+        "color": "#000000",
+        "alignment": "right",
+        "margin": [0, 0, 0, 10]
+      },
       "form-header": {
         "color": "#484848",
         "fontFamily": "Roboto",

--- a/pdf-service/format-config/warrant-generic.json
+++ b/pdf-service/format-config/warrant-generic.json
@@ -31,6 +31,11 @@
         "layout": "noBorders"
       },
       {
+        "text": "Next Hearing Date: {{hearingDate}}",
+        "style": "next-hearing-date",
+        "layout": "noBorders"
+      },
+      {
         "style": "form-body",
         "table": {
           "widths": ["*"],
@@ -122,6 +127,13 @@
         "fontSize": 12,
         "color": "#484848",
         "alignment": "right"
+      },
+      "next-hearing-date": {
+        "fontSize": 12,
+        "bold": true,
+        "color": "#000000",
+        "alignment": "right",
+        "margin": [0, 0, 0, 10]
       },
       "footer-content": {
         "color": "#484848",

--- a/pdf-service/format-config/warrants-bailable.json
+++ b/pdf-service/format-config/warrants-bailable.json
@@ -54,6 +54,11 @@
         "layout": "noBorders"
       },
       {
+        "text": "Next Hearing Date: {{hearingDate}}",
+        "style": "next-hearing-date",
+        "layout": "noBorders"
+      },
+      {
         "style": "form-body",
         "table": {
           "widths": [
@@ -215,6 +220,13 @@
       }
     ],
     "styles": {
+      "next-hearing-date": {
+        "fontSize": 12,
+        "bold": true,
+        "color": "#000000",
+        "alignment": "right",
+        "margin": [0, 0, 0, 10]
+      },
       "tl-head": {
         "fillColor": "white",
         "margin": [

--- a/pdf-service/format-config/warrants-non-bailable.json
+++ b/pdf-service/format-config/warrants-non-bailable.json
@@ -55,6 +55,11 @@
         "layout": "noBorders"
       },
       {
+        "text": "Next Hearing Date: {{hearingDate}}",
+        "style": "next-hearing-date",
+        "layout": "noBorders"
+      },
+      {
         "style": "form-body",
         "table": {
           "widths": [
@@ -176,6 +181,18 @@
         "fontSize": 12,
         "color": "#484848",
         "alignment": "right"
+      },
+      "next-hearing-date": {
+        "fontSize": 12,
+        "bold": true,
+        "color": "#000000",
+        "alignment": "right",
+        "margin": [
+          0,
+          0,
+          0,
+          10
+        ]
       },
       "footer-content": {
         "color": "#484848",

--- a/pdf-service/format-config/witness-warrant-pdf.json
+++ b/pdf-service/format-config/witness-warrant-pdf.json
@@ -54,6 +54,11 @@
         "layout": "noBorders"
       },
       {
+        "text": "Next Hearing Date: {{hearingDate}}",
+        "style": "next-hearing-date",
+        "layout": "noBorders"
+      },
+      {
         "style": "form-body",
         "table": {
           "widths": [
@@ -129,6 +134,13 @@
       }
     ],
     "styles": {
+      "next-hearing-date": {
+        "fontSize": 12,
+        "bold": true,
+        "color": "#000000",
+        "alignment": "right",
+        "margin": [0, 0, 0, 10]
+      },
       "tl-head": {
         "fillColor": "white",
         "margin": [


### PR DESCRIPTION
Cherry-pick of #762 (squash commit `fe762a3`) onto `master`.

## What
Adds a bold, right-aligned **Next Hearing Date: {{hearingDate}}** line to 10 `pdf-service` format-config templates:
- Warrants/summons (below the title): `warrant-generic`, `warrants-non-bailable`, `warrants-bailable`, `witness-warrant-pdf`, `summons-accused`, `summons-witness`
- Notices (below the Petitioner/Accused line): `bnss-notice`, `bnss-notice-epost`, `dca-notice`, `dca-notice-epost`

## Notes
- format-config only; `hearingDate` already flows from `summons-svc` and is mapped in every data-config.
- `-qr` / `-qr-epost` variants not included; date format left as-is (dd/MM/yyyy deferred).
- Pre-existing backend key mismatches to confirm separately: witness-warrant (`warrant-witness` vs `witness-warrant-pdf`), e-post (`-e-post` vs `-epost`).

QA signed off: https://github.com/pucardotorg/dristi/issues/5796#issuecomment-4729299480
Cherry-pick for https://github.com/pucardotorg/dristi/issues/5796

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Next Hearing Date is now displayed on all generated legal documents, including notices, summons, warrants, and witness documents. This provides users with clear visibility of upcoming court proceedings directly within each document.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->