### PR TITLE
fix(pdf): repair unclosed Mustache sections in application-profile-edit template

### DIFF
--- a/pdf-service/format-config/application-profile-edit.json
+++ b/pdf-service/format-config/application-profile-edit.json
@@ -177,7 +177,6 @@
                     "text": "Addresses:",
                     "style": "bodyText"
                   },
-                  "{{#currentPermanentAddress}}",
                   {
                     "text": "{{address}}",
                     "style": "bodyText"
@@ -238,7 +237,6 @@
                     "text": "Addresses:",
                     "style": "bodyText"
                   },
-                  "{{#newPermanentAddress}}",
                   {
                     "text": "{{address}}",
                     "style": "bodyText"
@@ -249,7 +247,6 @@
                     "text": "Addresses:",
                     "style": "bodyText"
                   },
-                  "{{/newResedentialAddress}}",
                   {
                     "text": "{{address}}",
                     "style": "bodyText"


### PR DESCRIPTION
## Problem
Profile Correction Application PDF preview (non-QR) fails with HTTP 500. `dristi-pdf` calls `pdf-service`, which throws:

```
[ERROR] [pdf-service] Error: Unclosed section "newPermanentAddress" at 3553
```

The `application-profile-edit.json` format-config had malformed Mustache address sections:
- duplicate opening tag `{{#currentPermanentAddress}}` (opened twice, closed once)
- duplicate opening tag `{{#newPermanentAddress}}` (opened twice, closed once)
- a premature `{{/newResedentialAddress}}` close that orphaned `{{address}}` and left `newPermanentAddress` unclosed

The parser hit a mismatched close tag and aborted with a 400, which surfaced as a 500 in the UI ("Preview for this Document is not available"). Deterministic — affects all non-QR Profile Correction previews.

## Fix
Removed the 3 stray lines so every address block is a single balanced `{{#X}} … {{/X}}` pair, matching the already-correct `application-profile-edit-qr.json` template. JSON validated.

## Testing
- `python -m json.tool` passes
- All six address sections now have matching open/close tags
- Structure is identical to the working `-qr` variant

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected address section rendering in the application profile PDF template to ensure proper formatting and display of address entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->