### PR TITLE
fix(pdf-service): profile-edit signature uses advocateRepresentingName

### DIFF
--- a/pdf-service/data-config/application-profile-edit.json
+++ b/pdf-service/data-config/application-profile-edit.json
@@ -109,6 +109,12 @@
                 }
               },
               {
+                "variable": "advocateRepresentingName",
+                "value": {
+                  "path": "$.advocateRepresentingName"
+                }
+              },
+              {
                 "variable": "currentName",
                 "value": {
                   "path": "$.currentName"

--- a/pdf-service/format-config/application-profile-edit.json
+++ b/pdf-service/format-config/application-profile-edit.json
@@ -294,7 +294,7 @@
                     "margin": [0, 60, 0, 5]
                   },
                   {
-                    "text": "Advocate for {{partyName}}",
+                    "text": "Advocate for {{advocateRepresentingName}}",
                     "style": "signature"
                   }
                 ],


### PR DESCRIPTION
Addresses https://github.com/pucardotorg/dristi/issues/5275

Maps the new `advocateRepresentingName` variable in the data-config and points the profile-edit "Advocate for" signature line at it instead of `partyName`. Paired with the dristi-solutions handler PR.