### PR TITLE
fix(pdf): party details table for summons to witness (#5871)

### DIFF
--- a/pdf-service/data-config/summons-witness-epost.json
+++ b/pdf-service/data-config/summons-witness-epost.json
@@ -137,6 +137,22 @@
                   "path": "$.address.pincode",
                   "defaultValue": "NA"
                 }
+              },
+              {
+                "variable": "complainantList",
+                "value": {
+                  "path": "$.complainantList"
+                },
+                "type": "function",
+                "format": " var i = 0; for (i=0;i< type.length;i++) {type[i]['index'] = i + 1;} return type;"
+              },
+              {
+                "variable": "accusedList",
+                "value": {
+                  "path": "$.accusedList"
+                },
+                "type": "function",
+                "format": " var i = 0; for (i=0;i< type.length;i++) {type[i]['index'] = i + 1;} return type;"
               }
             ]
           }

--- a/pdf-service/data-config/summons-witness.json
+++ b/pdf-service/data-config/summons-witness.json
@@ -137,6 +137,22 @@
                   "path": "$.address.pincode",
                   "defaultValue": "NA"
                 }
+              },
+              {
+                "variable": "complainantList",
+                "value": {
+                  "path": "$.complainantList"
+                },
+                "type": "function",
+                "format": " var i = 0; for (i=0;i< type.length;i++) {type[i]['index'] = i + 1;} return type;"
+              },
+              {
+                "variable": "accusedList",
+                "value": {
+                  "path": "$.accusedList"
+                },
+                "type": "function",
+                "format": " var i = 0; for (i=0;i< type.length;i++) {type[i]['index'] = i + 1;} return type;"
               }
             ]
           }

--- a/pdf-service/format-config/summons-witness-epost.json
+++ b/pdf-service/format-config/summons-witness-epost.json
@@ -89,6 +89,18 @@
               }
             ],
             "{{/complainantList}}",
+            [
+              {
+                "text": "",
+                "style": "party-cell",
+                "border": [true, false, false, false]
+              },
+              {
+                "text": "",
+                "style": "party-cell",
+                "border": [false, false, true, false]
+              }
+            ],
             "{{#accusedList}}",
             [
               {
@@ -115,6 +127,18 @@
               }
             ],
             "{{/accusedList}}",
+            [
+              {
+                "text": "",
+                "style": "party-cell",
+                "border": [true, false, false, false]
+              },
+              {
+                "text": "",
+                "style": "party-cell",
+                "border": [false, false, true, false]
+              }
+            ],
             [
               {
                 "text": "Offence",

--- a/pdf-service/format-config/summons-witness-epost.json
+++ b/pdf-service/format-config/summons-witness-epost.json
@@ -54,6 +54,84 @@
         "layout": "noBorders"
       },
       {
+        "text": "Next Hearing Date: {{hearingDate}}",
+        "style": "next-hearing-date",
+        "layout": "noBorders"
+      },
+      {
+        "style": "party-table",
+        "table": {
+          "widths": ["30%", "70%"],
+          "body": [
+            "{{#complainantList}}",
+            [
+              {
+                "text": "Complainant {{index}}",
+                "style": "party-cell",
+                "border": [true, true, true, true]
+              },
+              {
+                "text": "{{name}}",
+                "style": "party-cell",
+                "border": [true, true, true, true]
+              }
+            ],
+            [
+              {
+                "text": "Advocate(s)",
+                "style": "party-cell",
+                "border": [true, true, true, true]
+              },
+              {
+                "text": "{{listOfAdvocatesRepresenting}}",
+                "style": "party-cell",
+                "border": [true, true, true, true]
+              }
+            ],
+            "{{/complainantList}}",
+            "{{#accusedList}}",
+            [
+              {
+                "text": "Accused {{index}}",
+                "style": "party-cell",
+                "border": [true, true, true, true]
+              },
+              {
+                "text": "{{name}}",
+                "style": "party-cell",
+                "border": [true, true, true, true]
+              }
+            ],
+            [
+              {
+                "text": "Advocate(s)",
+                "style": "party-cell",
+                "border": [true, true, true, true]
+              },
+              {
+                "text": "{{listOfAdvocatesRepresenting}}",
+                "style": "party-cell",
+                "border": [true, true, true, true]
+              }
+            ],
+            "{{/accusedList}}",
+            [
+              {
+                "text": "Offence",
+                "style": "party-cell",
+                "border": [true, true, true, true]
+              },
+              {
+                "text": "S.138 of the Negotiable Instruments Act, 1881",
+                "style": "party-cell",
+                "border": [true, true, true, true]
+              }
+            ]
+          ]
+        },
+        "margin": [0, 10, 0, 10]
+      },
+      {
         "style": "form-body",
         "table": {
           "widths": ["*"],
@@ -66,7 +144,7 @@
             ],
             [
               {
-                "text": "WHEREAS complaint has been made before me that {{respondentName}} of {{respondentAddress}} has (or is suspected to have) committed the offence  U/s. 138 of Negotiable Instruments Act, and it appears to me that you are likely to give material evidence or to produce any document or other thing for the prosecution;",
+                "text": "In the above mentioned case, involving the above listed parties, it appears to me that you are likely to give material evidence or to produce any document or other thing;",
                 "style": "form-sub-body"
               }
             ],
@@ -137,6 +215,22 @@
       }
     ],
     "styles": {
+      "next-hearing-date": {
+        "fontSize": 12,
+        "bold": true,
+        "color": "#000000",
+        "alignment": "right",
+        "margin": [0, 0, 0, 10]
+      },
+      "party-table": {
+        "fontSize": 12,
+        "color": "#484848"
+      },
+      "party-cell": {
+        "fontSize": 12,
+        "color": "#484848",
+        "margin": [2, 5, 2, 5]
+      },
       "form-header": {
         "color": "#484848",
         "fontFamily": "Roboto",

--- a/pdf-service/format-config/summons-witness.json
+++ b/pdf-service/format-config/summons-witness.json
@@ -59,6 +59,79 @@
         "layout": "noBorders"
       },
       {
+        "style": "party-table",
+        "table": {
+          "widths": ["30%", "70%"],
+          "body": [
+            "{{#complainantList}}",
+            [
+              {
+                "text": "Complainant {{index}}",
+                "style": "party-cell",
+                "border": [true, true, true, true]
+              },
+              {
+                "text": "{{name}}",
+                "style": "party-cell",
+                "border": [true, true, true, true]
+              }
+            ],
+            [
+              {
+                "text": "Advocate(s)",
+                "style": "party-cell",
+                "border": [true, true, true, true]
+              },
+              {
+                "text": "{{listOfAdvocatesRepresenting}}",
+                "style": "party-cell",
+                "border": [true, true, true, true]
+              }
+            ],
+            "{{/complainantList}}",
+            "{{#accusedList}}",
+            [
+              {
+                "text": "Accused {{index}}",
+                "style": "party-cell",
+                "border": [true, true, true, true]
+              },
+              {
+                "text": "{{name}}",
+                "style": "party-cell",
+                "border": [true, true, true, true]
+              }
+            ],
+            [
+              {
+                "text": "Advocate(s)",
+                "style": "party-cell",
+                "border": [true, true, true, true]
+              },
+              {
+                "text": "{{listOfAdvocatesRepresenting}}",
+                "style": "party-cell",
+                "border": [true, true, true, true]
+              }
+            ],
+            "{{/accusedList}}",
+            [
+              {
+                "text": "Offence",
+                "style": "party-cell",
+                "border": [true, true, true, true]
+              },
+              {
+                "text": "S.138 of the Negotiable Instruments Act, 1881",
+                "style": "party-cell",
+                "border": [true, true, true, true]
+              }
+            ]
+          ]
+        },
+        "margin": [0, 10, 0, 10]
+      },
+      {
         "style": "form-body",
         "table": {
           "widths": ["*"],
@@ -71,7 +144,7 @@
             ],
             [
               {
-                "text": "WHEREAS complaint has been made before me that {{respondentName}} of {{respondentAddress}} has (or is suspected to have) committed the offence  U/s. 138 of Negotiable Instruments Act, and it appears to me that you are likely to give material evidence or to produce any document or other thing for the prosecution;",
+                "text": "In the above mentioned case, involving the above listed parties, it appears to me that you are likely to give material evidence or to produce any document or other thing;",
                 "style": "form-sub-body"
               }
             ],
@@ -122,6 +195,15 @@
         "color": "#000000",
         "alignment": "right",
         "margin": [0, 0, 0, 10]
+      },
+      "party-table": {
+        "fontSize": 12,
+        "color": "#484848"
+      },
+      "party-cell": {
+        "fontSize": 12,
+        "color": "#484848",
+        "margin": [2, 5, 2, 5]
       },
       "form-header": {
         "color": "#484848",

--- a/pdf-service/format-config/summons-witness.json
+++ b/pdf-service/format-config/summons-witness.json
@@ -89,6 +89,18 @@
               }
             ],
             "{{/complainantList}}",
+            [
+              {
+                "text": "",
+                "style": "party-cell",
+                "border": [true, false, false, false]
+              },
+              {
+                "text": "",
+                "style": "party-cell",
+                "border": [false, false, true, false]
+              }
+            ],
             "{{#accusedList}}",
             [
               {
@@ -115,6 +127,18 @@
               }
             ],
             "{{/accusedList}}",
+            [
+              {
+                "text": "",
+                "style": "party-cell",
+                "border": [true, false, false, false]
+              },
+              {
+                "text": "",
+                "style": "party-cell",
+                "border": [false, false, true, false]
+              }
+            ],
             [
               {
                 "text": "Offence",


### PR DESCRIPTION
## Summary

Addresses https://github.com/pucardotorg/dristi/issues/5871

Reworks the **summons to witness** PDF templates so the accused is no longer mis-named with the witness's name.

- Removes the `WHEREAS ... {{respondentName}}` clause (for a witness summons `respondentName` is the witness, which is what produced the wrong wording reported on prod, ST/437/2025).
- After "Next Hearing Date", adds the **party details table** — complainant(s) + accused + representing advocates + offence — the same table used in orders/applications, so multiple accused are covered.
- Adds the sentence "In the above mentioned case, involving the above listed parties, it appears to me that you are likely to give material evidence or to produce any document or other thing;".
- `data-config`: adds `complainantList` / `accusedList` mappings (index-enriched, mirroring case-summary).

Applies to `summons-witness` and `summons-witness-e-post` (the two court-approved, non-QR variants). The `Offence` row is hardcoded "S.138 of the Negotiable Instruments Act, 1881", matching every other template in this repo (application-generic, new-order-generic, case-summary) — there is no dynamic offence variable.

Paired backend PR (summons-svc supplies the party lists): https://github.com/pucardotorg/dristi-solutions/pull/6844

Verified on DEV + QA: both templates render the party table (multiple complainants/accused, empty-advocate handled) with no blank page / malformed-row error, and no witness-name-in-accused-slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)