### PR TITLE
Release 35: promote develop to master

### DIFF
--- a/pdf-service/data-config/case-summary.json
+++ b/pdf-service/data-config/case-summary.json
@@ -1,0 +1,68 @@
+{
+  "key": "case-summary",
+  "DataConfigs": {
+    "serviceName": "pdf-service",
+    "version": "1.0.0",
+    "baseKeyPath": "$.Data.*",
+    "entityIdPath": "$.id",
+    "isCommonTableBorderRequired": true,
+    "mappings": [
+      {
+        "topic": "common-pdf-generation-3",
+        "mappings": [
+          {
+            "direct": [
+              {
+                "variable": "courtName",
+                "value": {
+                  "path": "$.courtName"
+                }
+              },
+              {
+                "variable": "caseNumber",
+                "value": {
+                  "path": "$.caseNumber"
+                }
+              },
+              {
+                "variable": "caseName",
+                "value": {
+                  "path": "$.caseName"
+                }
+              },
+              {
+                "variable": "date",
+                "value": {
+                  "path": "$.date"
+                }
+              },
+              {
+                "variable": "complainantList",
+                "value": {
+                  "path": "$.complainantList"
+                },
+                "type": "function",
+                "format": " var i = 0; for (i=0;i< type.length;i++) {type[i]['index'] = i + 1;} return type;"
+              },
+              {
+                "variable": "accusedList",
+                "value": {
+                  "path": "$.accusedList"
+                },
+                "type": "function",
+                "format": " var i = 0; for (i=0;i< type.length;i++) {type[i]['index'] = i + 1;} return type;"
+              },
+              {
+                "variable": "hearings",
+                "value": {
+                  "path": "$.hearings"
+                },
+                "type": "index"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/pdf-service/data-config/summons-witness-epost.json
+++ b/pdf-service/data-config/summons-witness-epost.json
@@ -137,6 +137,22 @@
                   "path": "$.address.pincode",
                   "defaultValue": "NA"
                 }
+              },
+              {
+                "variable": "complainantList",
+                "value": {
+                  "path": "$.complainantList"
+                },
+                "type": "function",
+                "format": " var i = 0; for (i=0;i< type.length;i++) {type[i]['index'] = i + 1;} return type;"
+              },
+              {
+                "variable": "accusedList",
+                "value": {
+                  "path": "$.accusedList"
+                },
+                "type": "function",
+                "format": " var i = 0; for (i=0;i< type.length;i++) {type[i]['index'] = i + 1;} return type;"
               }
             ]
           }

--- a/pdf-service/data-config/summons-witness.json
+++ b/pdf-service/data-config/summons-witness.json
@@ -137,6 +137,22 @@
                   "path": "$.address.pincode",
                   "defaultValue": "NA"
                 }
+              },
+              {
+                "variable": "complainantList",
+                "value": {
+                  "path": "$.complainantList"
+                },
+                "type": "function",
+                "format": " var i = 0; for (i=0;i< type.length;i++) {type[i]['index'] = i + 1;} return type;"
+              },
+              {
+                "variable": "accusedList",
+                "value": {
+                  "path": "$.accusedList"
+                },
+                "type": "function",
+                "format": " var i = 0; for (i=0;i< type.length;i++) {type[i]['index'] = i + 1;} return type;"
               }
             ]
           }

--- a/pdf-service/format-config/case-summary.json
+++ b/pdf-service/format-config/case-summary.json
@@ -1,0 +1,226 @@
+{
+  "key": "case-summary",
+  "config": {
+    "pageSize": "A4",
+    "pageMargins": [40, 40, 40, 40],
+    "content": [
+      {
+        "table": {
+          "widths": ["*"],
+          "body": [
+            [
+              {
+                "stack": [
+                  {
+                    "text": "Before {{courtName}}",
+                    "style": "header"
+                  },
+                  {
+                    "text": "Case No: {{caseNumber}}",
+                    "style": "header",
+                    "margin": [0, 5, 0, 0]
+                  },
+                  {
+                    "text": "In the matter of: {{caseName}}",
+                    "style": "header",
+                    "margin": [0, 5, 0, 0]
+                  },
+                  {
+                    "text": "Date: {{date}}",
+                    "style": "header",
+                    "margin": [0, 5, 0, 15]
+                  },
+                  {
+                    "style": "table",
+                    "table": {
+                      "widths": ["30%", "70%"],
+                      "body": [
+                        "{{#complainantList}}",
+                        [
+                          {
+                            "text": "Complainant {{index}}",
+                            "style": "tableText",
+                            "border": [true, true, true, true]
+                          },
+                          {
+                            "text": "{{name}}",
+                            "style": "tableText",
+                            "border": [true, true, true, true]
+                          }
+                        ],
+                        [
+                          {
+                            "text": "Advocate(s)",
+                            "style": "tableText",
+                            "border": [true, true, true, true]
+                          },
+                          {
+                            "text": "{{listOfAdvocatesRepresenting}}",
+                            "style": "tableText",
+                            "border": [true, true, true, true]
+                          }
+                        ],
+                        "{{/complainantList}}",
+                        [
+                          {
+                            "text": "",
+                            "style": "tableText",
+                            "border": [true, false, false, false]
+                          },
+                          {
+                            "text": "",
+                            "style": "tableText",
+                            "border": [false, false, true, false]
+                          }
+                        ],
+                        "{{#accusedList}}",
+                        [
+                          {
+                            "text": "Accused {{index}}",
+                            "style": "tableText",
+                            "border": [true, true, true, true]
+                          },
+                          {
+                            "text": "{{name}}",
+                            "style": "tableText",
+                            "border": [true, true, true, true]
+                          }
+                        ],
+                        [
+                          {
+                            "text": "Advocate(s)",
+                            "style": "tableText",
+                            "border": [true, true, true, true]
+                          },
+                          {
+                            "text": "{{listOfAdvocatesRepresenting}}",
+                            "style": "tableText",
+                            "border": [true, true, true, true]
+                          }
+                        ],
+                        "{{/accusedList}}",
+                        [
+                          {
+                            "text": "",
+                            "style": "tableText",
+                            "border": [true, false, false, false]
+                          },
+                          {
+                            "text": "",
+                            "style": "tableText",
+                            "border": [false, false, true, false]
+                          }
+                        ],
+                        [
+                          {
+                            "text": "Offence",
+                            "style": "tableText",
+                            "border": [true, true, true, true]
+                          },
+                          {
+                            "text": "S.138 of the Negotiable Instruments Act, 1881",
+                            "style": "tableText",
+                            "border": [true, true, true, true]
+                          }
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "text": "",
+                    "margin": [0, 0, 0, 15]
+                  },
+                  {
+                    "style": "hearingTable",
+                    "table": {
+                      "headerRows": 1,
+                      "widths": ["35%", "65%"],
+                      "body": [
+                        [
+                          {
+                            "text": "Date and Purpose of Hearing",
+                            "style": "hearingTableHeader",
+                            "border": [true, true, true, true]
+                          },
+                          {
+                            "text": "BoTD",
+                            "style": "hearingTableHeader",
+                            "border": [true, true, true, true]
+                          }
+                        ],
+                        "{{#hearings}}",
+                        [
+                          {
+                            "stack": [
+                              {
+                                "text": "{{date}}",
+                                "style": "hearingDate"
+                              },
+                              {
+                                "text": "{{purpose}}",
+                                "style": "hearingPurpose"
+                              }
+                            ],
+                            "border": [true, true, true, true]
+                          },
+                          {
+                            "text": "{{businessOfTheDay}}",
+                            "style": "hearingBotd",
+                            "border": [true, true, true, true]
+                          }
+                        ],
+                        "{{/hearings}}"
+                      ]
+                    }
+                  }
+                ],
+                "alignment": "left",
+                "margin": [0, 20, 0, 20]
+              }
+            ]
+          ]
+        },
+        "layout": "noBorders"
+      }
+    ],
+    "styles": {
+      "header": {
+        "fontSize": 14,
+        "bold": true,
+        "alignment": "center",
+        "margin": [0, 0, 0, 0]
+      },
+      "table": {
+        "fontSize": 13
+      },
+      "tableText": {
+        "fontSize": 13,
+        "margin": [2, 5, 2, 5]
+      },
+      "hearingTable": {
+        "fontSize": 12
+      },
+      "hearingTableHeader": {
+        "fontSize": 12,
+        "bold": true,
+        "fillColor": "#EAEAEA",
+        "margin": [4, 6, 4, 6]
+      },
+      "hearingDate": {
+        "fontSize": 12,
+        "bold": true,
+        "margin": [4, 6, 4, 2]
+      },
+      "hearingPurpose": {
+        "fontSize": 11,
+        "color": "#3D3C3C",
+        "margin": [4, 0, 4, 6]
+      },
+      "hearingBotd": {
+        "fontSize": 11,
+        "alignment": "justify",
+        "margin": [4, 6, 4, 6]
+      }
+    }
+  }
+}

--- a/pdf-service/format-config/summons-witness-epost.json
+++ b/pdf-service/format-config/summons-witness-epost.json
@@ -54,6 +54,108 @@
         "layout": "noBorders"
       },
       {
+        "text": "Next Hearing Date: {{hearingDate}}",
+        "style": "next-hearing-date",
+        "layout": "noBorders"
+      },
+      {
+        "style": "party-table",
+        "table": {
+          "widths": ["30%", "70%"],
+          "body": [
+            "{{#complainantList}}",
+            [
+              {
+                "text": "Complainant {{index}}",
+                "style": "party-cell",
+                "border": [true, true, true, true]
+              },
+              {
+                "text": "{{name}}",
+                "style": "party-cell",
+                "border": [true, true, true, true]
+              }
+            ],
+            [
+              {
+                "text": "Advocate(s)",
+                "style": "party-cell",
+                "border": [true, true, true, true]
+              },
+              {
+                "text": "{{listOfAdvocatesRepresenting}}",
+                "style": "party-cell",
+                "border": [true, true, true, true]
+              }
+            ],
+            "{{/complainantList}}",
+            [
+              {
+                "text": "",
+                "style": "party-cell",
+                "border": [true, false, false, false]
+              },
+              {
+                "text": "",
+                "style": "party-cell",
+                "border": [false, false, true, false]
+              }
+            ],
+            "{{#accusedList}}",
+            [
+              {
+                "text": "Accused {{index}}",
+                "style": "party-cell",
+                "border": [true, true, true, true]
+              },
+              {
+                "text": "{{name}}",
+                "style": "party-cell",
+                "border": [true, true, true, true]
+              }
+            ],
+            [
+              {
+                "text": "Advocate(s)",
+                "style": "party-cell",
+                "border": [true, true, true, true]
+              },
+              {
+                "text": "{{listOfAdvocatesRepresenting}}",
+                "style": "party-cell",
+                "border": [true, true, true, true]
+              }
+            ],
+            "{{/accusedList}}",
+            [
+              {
+                "text": "",
+                "style": "party-cell",
+                "border": [true, false, false, false]
+              },
+              {
+                "text": "",
+                "style": "party-cell",
+                "border": [false, false, true, false]
+              }
+            ],
+            [
+              {
+                "text": "Offence",
+                "style": "party-cell",
+                "border": [true, true, true, true]
+              },
+              {
+                "text": "S.138 of the Negotiable Instruments Act, 1881",
+                "style": "party-cell",
+                "border": [true, true, true, true]
+              }
+            ]
+          ]
+        },
+        "margin": [0, 10, 0, 10]
+      },
+      {
         "style": "form-body",
         "table": {
           "widths": ["*"],
@@ -66,7 +168,7 @@
             ],
             [
               {
-                "text": "WHEREAS complaint has been made before me that {{respondentName}} of {{respondentAddress}} has (or is suspected to have) committed the offence  U/s. 138 of Negotiable Instruments Act, and it appears to me that you are likely to give material evidence or to produce any document or other thing for the prosecution;",
+                "text": "In the above mentioned case, involving the above listed parties, it appears to me that you are likely to give material evidence or to produce any document or other thing;",
                 "style": "form-sub-body"
               }
             ],
@@ -137,6 +239,22 @@
       }
     ],
     "styles": {
+      "next-hearing-date": {
+        "fontSize": 12,
+        "bold": true,
+        "color": "#000000",
+        "alignment": "right",
+        "margin": [0, 0, 0, 10]
+      },
+      "party-table": {
+        "fontSize": 12,
+        "color": "#484848"
+      },
+      "party-cell": {
+        "fontSize": 12,
+        "color": "#484848",
+        "margin": [2, 5, 2, 5]
+      },
       "form-header": {
         "color": "#484848",
         "fontFamily": "Roboto",

--- a/pdf-service/format-config/summons-witness.json
+++ b/pdf-service/format-config/summons-witness.json
@@ -59,6 +59,103 @@
         "layout": "noBorders"
       },
       {
+        "style": "party-table",
+        "table": {
+          "widths": ["30%", "70%"],
+          "body": [
+            "{{#complainantList}}",
+            [
+              {
+                "text": "Complainant {{index}}",
+                "style": "party-cell",
+                "border": [true, true, true, true]
+              },
+              {
+                "text": "{{name}}",
+                "style": "party-cell",
+                "border": [true, true, true, true]
+              }
+            ],
+            [
+              {
+                "text": "Advocate(s)",
+                "style": "party-cell",
+                "border": [true, true, true, true]
+              },
+              {
+                "text": "{{listOfAdvocatesRepresenting}}",
+                "style": "party-cell",
+                "border": [true, true, true, true]
+              }
+            ],
+            "{{/complainantList}}",
+            [
+              {
+                "text": "",
+                "style": "party-cell",
+                "border": [true, false, false, false]
+              },
+              {
+                "text": "",
+                "style": "party-cell",
+                "border": [false, false, true, false]
+              }
+            ],
+            "{{#accusedList}}",
+            [
+              {
+                "text": "Accused {{index}}",
+                "style": "party-cell",
+                "border": [true, true, true, true]
+              },
+              {
+                "text": "{{name}}",
+                "style": "party-cell",
+                "border": [true, true, true, true]
+              }
+            ],
+            [
+              {
+                "text": "Advocate(s)",
+                "style": "party-cell",
+                "border": [true, true, true, true]
+              },
+              {
+                "text": "{{listOfAdvocatesRepresenting}}",
+                "style": "party-cell",
+                "border": [true, true, true, true]
+              }
+            ],
+            "{{/accusedList}}",
+            [
+              {
+                "text": "",
+                "style": "party-cell",
+                "border": [true, false, false, false]
+              },
+              {
+                "text": "",
+                "style": "party-cell",
+                "border": [false, false, true, false]
+              }
+            ],
+            [
+              {
+                "text": "Offence",
+                "style": "party-cell",
+                "border": [true, true, true, true]
+              },
+              {
+                "text": "S.138 of the Negotiable Instruments Act, 1881",
+                "style": "party-cell",
+                "border": [true, true, true, true]
+              }
+            ]
+          ]
+        },
+        "margin": [0, 10, 0, 10]
+      },
+      {
         "style": "form-body",
         "table": {
           "widths": ["*"],
@@ -71,7 +168,7 @@
             ],
             [
               {
-                "text": "WHEREAS complaint has been made before me that {{respondentName}} of {{respondentAddress}} has (or is suspected to have) committed the offence  U/s. 138 of Negotiable Instruments Act, and it appears to me that you are likely to give material evidence or to produce any document or other thing for the prosecution;",
+                "text": "In the above mentioned case, involving the above listed parties, it appears to me that you are likely to give material evidence or to produce any document or other thing;",
                 "style": "form-sub-body"
               }
             ],
@@ -122,6 +219,15 @@
         "color": "#000000",
         "alignment": "right",
         "margin": [0, 0, 0, 10]
+      },
+      "party-table": {
+        "fontSize": 12,
+        "color": "#484848"
+      },
+      "party-cell": {
+        "fontSize": 12,
+        "color": "#484848",
+        "margin": [2, 5, 2, 5]
       },
       "form-header": {
         "color": "#484848",


### PR DESCRIPTION
## Summary

Release cut **release/35** — promotes the accumulated `develop` config changes to production (`master`).

This is the paired configuration release for `dristi-solutions` `release/35`. Changes included:

- PDF party-details table config for summons to witness (Related to https://github.com/pucardotorg/dristi/issues/5871)
- Case-summary PDF data/format config (Related to https://github.com/pucardotorg/dristi/issues/5754)

## Other

- Target environment: `master` → demo/prod.
- Paired code release: `dristi-solutions` `release/35` → `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added case summary PDF generation with structured case details, parties, and hearing information.
  * Enhanced summons and witness documents to display complainant and accused party lists with numbering.
  * Added party, offence, and next-hearing sections to summons templates.
* **Improvements**
  * Updated summons wording and formatting for clearer presentation.
  * Improved table layouts and styling across generated PDF documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->